### PR TITLE
Add M2 inline parsing, M3 tables, and Markdown conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ cd geml-parser
 npm install
 npm run build
 node dist/geml.js ../GEML-spec-draft.geml   # → document-model JSON
+npm test                                    # M2 conformance checks
 ```
 
-**Status:** 0.1 draft.
+Milestones:
+
+- **M1** — block scanner: typed-block fences, `meta` data block, headings,
+  lists, paragraphs, attribute objects with §4 value typing.
+- **M2** — inline content (§5: emphasis/strong/strike, code, math, media
+  embeds, links, auto-references, footnotes) and build-time reference
+  validation (§8: unique ids, resolvable internal/cross-document references).
+
+**Status:** 0.1 draft, parser at M2.

--- a/README.md
+++ b/README.md
@@ -37,5 +37,8 @@ Milestones:
 - **M2** — inline content (§5: emphasis/strong/strike, code, math, media
   embeds, links, auto-references, footnotes) and build-time reference
   validation (§8: unique ids, resolvable internal/cross-document references).
+- **M3** — tables (§6: visual and `csv`/`tsv` forms parsed to one model,
+  per-row `compute` formulas with `sum/avg/min/max/count` aggregates, `span`
+  merges) and the diagram renderer registry (§7: unknown `format` → warning).
 
-**Status:** 0.1 draft, parser at M2.
+**Status:** 0.1 draft, parser covers §3–§8.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,24 @@ cd geml-parser
 npm install
 npm run build
 node dist/geml.js ../GEML-spec-draft.geml   # → document-model JSON
-npm test                                    # M2 conformance checks
+node dist/geml.js convert in.md -o out.geml # Markdown → GEML
+npm test                                    # conformance checks
 ```
+
+### Markdown → GEML
+
+`geml convert <file.md> [-o out.geml]` maps Markdown's block constructs onto
+GEML's typed-block primitive (inline syntax passes through, being a subset):
+
+| Markdown | GEML |
+|----------|------|
+| YAML frontmatter | `=== meta` (data) |
+| ` ``` ` fenced code | `=== code {lang=…}` |
+| `$$ … $$` math | `=== math` |
+| `>` blockquote | `=== note` |
+| GFM pipe table | `=== table` (§6) |
+| setext heading | ATX heading |
+| thematic break (`---`) | dropped (not a GEML construct) |
 
 Milestones:
 

--- a/geml-parser/package.json
+++ b/geml-parser/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "tsc && node test/m2.test.mjs && node test/m3.test.mjs",
+    "test": "tsc && node test/m2.test.mjs && node test/m3.test.mjs && node test/convert.test.mjs",
+    "convert": "node dist/geml.js convert",
     "parse": "node dist/geml.js"
   },
   "license": "MIT",

--- a/geml-parser/package.json
+++ b/geml-parser/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "tsc && node test/m2.test.mjs",
+    "test": "tsc && node test/m2.test.mjs && node test/m3.test.mjs",
     "parse": "node dist/geml.js"
   },
   "license": "MIT",

--- a/geml-parser/package.json
+++ b/geml-parser/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "test": "tsc && node test/m2.test.mjs",
     "parse": "node dist/geml.js"
   },
   "license": "MIT",

--- a/geml-parser/src/attrs.ts
+++ b/geml-parser/src/attrs.ts
@@ -1,0 +1,60 @@
+// Shared attribute-object and value typing (§4), used by the block scanner
+// and the inline parser.
+
+export type Value = string | number | boolean;
+
+export interface Attrs {
+  id?: string;
+  classes: string[];
+  attrs: Record<string, Value>;
+}
+
+// §4 value typing: quoted -> string, true/false -> boolean, integer/float
+// syntax -> number, any other bare word -> string. No arrays/dates/tables.
+export function coerce(raw: string): Value {
+  const t = raw.trim();
+  if (t.length >= 2 && t.startsWith('"') && t.endsWith('"')) {
+    return t.slice(1, -1); // quoted -> always string
+  }
+  if (t === "true") return true;
+  if (t === "false") return false;
+  if (/^[+-]?\d+$/.test(t)) return parseInt(t, 10);
+  if (/^[+-]?(\d+\.\d*|\.\d+|\d+)([eE][+-]?\d+)?$/.test(t) && /[.eE]/.test(t)) return parseFloat(t);
+  return t; // bare word -> string
+}
+
+// Split on whitespace while keeping double-quoted spans intact.
+export function tokenize(s: string): string[] {
+  const out: string[] = [];
+  let cur = "";
+  let inQuote = false;
+  for (const ch of s) {
+    if (ch === '"') {
+      inQuote = !inQuote;
+      cur += ch;
+    } else if (!inQuote && /\s/.test(ch)) {
+      if (cur) { out.push(cur); cur = ""; }
+    } else {
+      cur += ch;
+    }
+  }
+  if (cur) out.push(cur);
+  return out;
+}
+
+// Parse `{#id .class key=val key2="a b"}` (braces included).
+export function parseAttrs(src: string): Attrs {
+  const inner = src.trim().replace(/^\{/, "").replace(/\}$/, "");
+  const out: Attrs = { classes: [], attrs: {} };
+  for (const tok of tokenize(inner)) {
+    if (tok.startsWith("#")) {
+      out.id = tok.slice(1);
+    } else if (tok.startsWith(".")) {
+      out.classes.push(tok.slice(1));
+    } else {
+      const eq = tok.indexOf("=");
+      if (eq > 0) out.attrs[tok.slice(0, eq)] = coerce(tok.slice(eq + 1));
+    }
+  }
+  return out;
+}

--- a/geml-parser/src/from-md.ts
+++ b/geml-parser/src/from-md.ts
@@ -1,0 +1,162 @@
+// GEML reference parser — Markdown → GEML conversion.
+//
+// Markdown's inline syntax (emphasis/strong/strike, code, links, images,
+// footnotes) is already a subset of GEML's (§5), so inline text passes through
+// unchanged. The work is mapping block constructs onto GEML's single typed-block
+// primitive (§3):
+//
+//   YAML frontmatter      -> === meta            (data)
+//   ``` fenced code        -> === code {lang=…}   (raw)
+//   $$ … $$ math block     -> === math            (raw)
+//   > blockquote           -> === note            (flow)
+//   GFM pipe table         -> === table           (visual body, §6)
+//   setext heading         -> ATX heading (§1: GEML headings are ATX-only)
+//   thematic break (---/***) -> dropped           (§1: not part of GEML)
+//
+// Anything else (ATX headings, lists, paragraphs) is already valid GEML.
+
+export interface ConvertResult {
+  geml: string;
+  notes: string[]; // non-fatal remarks (dropped constructs, raw HTML, …)
+}
+
+// Pick a fence length longer than any run of `=` that appears alone on a body
+// line, so the close fence stays unambiguous (§3 equal-length close rule).
+function fenceFor(body: string[]): string {
+  let max = 2;
+  for (const l of body) {
+    const m = /^(=+)\s*$/.exec(l);
+    if (m) max = Math.max(max, m[1]!.length);
+  }
+  return "=".repeat(Math.max(3, max + 1));
+}
+
+function emitBlock(out: string[], type: string, attrs: string, body: string[]): void {
+  const fence = fenceFor(body);
+  out.push(attrs ? `${fence} ${type} ${attrs}` : `${fence} ${type}`);
+  out.push(...body);
+  out.push(fence);
+}
+
+// `key: value` (YAML-ish) -> `key=value`, quoting values that need it.
+function metaLine(line: string): string | null {
+  const m = /^([A-Za-z_][\w-]*)\s*:\s*(.*)$/.exec(line);
+  if (!m) return null;
+  let v = m[2]!.trim();
+  if (v === "") return `${m[1]}=""`;
+  // Strip existing YAML quotes; re-quote only when the bare value would be
+  // re-tokenized (contains whitespace or a quote).
+  if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
+  const bareSafe = /^[^\s"]+$/.test(v);
+  return bareSafe ? `${m[1]}=${v}` : `${m[1]}="${v.replace(/"/g, '\\"')}"`;
+}
+
+const FENCE = /^(\s*)(`{3,}|~{3,})(.*)$/;
+const SETEXT_UL = /^=+\s*$/;
+const SETEXT_DASH = /^-+\s*$/;
+const THEMATIC = /^\s*([-*_])(\s*\1){2,}\s*$/;
+const TABLE_SEP = /^\s*\|?\s*:?-{1,}:?\s*(\|\s*:?-{1,}:?\s*)*\|?\s*$/;
+
+export function mdToGeml(source: string): ConvertResult {
+  const lines = source.replace(/\r\n?/g, "\n").split("\n");
+  const out: string[] = [];
+  const notes: string[] = [];
+  let i = 0;
+
+  // YAML frontmatter (must be the very first line).
+  if (lines[0] === "---") {
+    let j = 1;
+    const meta: string[] = [];
+    while (j < lines.length && lines[j] !== "---" && lines[j] !== "...") {
+      const ml = metaLine(lines[j]!);
+      if (ml) meta.push(ml);
+      else if (lines[j]!.trim() !== "") notes.push(`frontmatter line not converted: ${lines[j]}`);
+      j++;
+    }
+    if (j < lines.length) { // closing marker found -> it was frontmatter
+      emitBlock(out, "meta", "", meta);
+      out.push("");
+      i = j + 1;
+    }
+  }
+
+  while (i < lines.length) {
+    const line = lines[i]!;
+
+    // Fenced code block.
+    const f = FENCE.exec(line);
+    if (f) {
+      const marker = f[2]!;
+      const info = f[3]!.trim().split(/\s+/)[0] ?? "";
+      const body: string[] = [];
+      let j = i + 1;
+      for (; j < lines.length; j++) {
+        const c = lines[j]!.trimStart();
+        if (c.startsWith(marker[0]!) && c.replace(/\s+$/, "").length >= marker.length && /^[`~]+$/.test(c.replace(/\s+$/, ""))) break;
+        body.push(lines[j]!);
+      }
+      emitBlock(out, "code", info ? `{lang=${info}}` : "", body);
+      i = j < lines.length ? j + 1 : j;
+      continue;
+    }
+
+    // Display math $$ … $$.
+    if (line.trim() === "$$") {
+      const body: string[] = [];
+      let j = i + 1;
+      for (; j < lines.length && lines[j]!.trim() !== "$$"; j++) body.push(lines[j]!);
+      emitBlock(out, "math", "", body);
+      i = j < lines.length ? j + 1 : j;
+      continue;
+    }
+
+    // Setext heading: a text line followed by `===` or `---` underline. Checked
+    // before the thematic-break drop so dash underlines aren't lost.
+    if (line.trim() !== "" && !THEMATIC.test(line) && i + 1 < lines.length) {
+      const nxt = lines[i + 1]!;
+      if (SETEXT_UL.test(nxt)) { out.push(`# ${line.trim()}`); i += 2; continue; }
+      if (SETEXT_DASH.test(nxt)) { out.push(`## ${line.trim()}`); i += 2; continue; }
+    }
+
+    // Thematic break (---, ***, ___) -> dropped (not a GEML construct). Any
+    // dash underline has already been consumed by the setext check above.
+    if (THEMATIC.test(line)) {
+      notes.push(`dropped thematic break at line ${i + 1}`);
+      i++;
+      continue;
+    }
+
+    // Blockquote -> === note (flow). Strips one `>` level per line.
+    if (/^\s*>/.test(line)) {
+      const body: string[] = [];
+      while (i < lines.length && /^\s*>/.test(lines[i]!)) {
+        body.push(lines[i]!.replace(/^\s*>\s?/, ""));
+        i++;
+      }
+      emitBlock(out, "note", "", body);
+      continue;
+    }
+
+    // GFM pipe table -> === table (visual body).
+    if (line.includes("|") && i + 1 < lines.length && TABLE_SEP.test(lines[i + 1]!) && line.trim() !== "") {
+      const body: string[] = [line];
+      let j = i + 1;
+      body.push(lines[j]!); // separator
+      j++;
+      while (j < lines.length && lines[j]!.includes("|") && lines[j]!.trim() !== "") { body.push(lines[j]!); j++; }
+      emitBlock(out, "table", "", body);
+      i = j;
+      continue;
+    }
+
+    if (/<[a-zA-Z/]/.test(line)) notes.push(`raw HTML kept as text at line ${i + 1}: ${line.trim().slice(0, 40)}`);
+
+    // Everything else (ATX headings, lists, paragraphs, blanks) is valid GEML.
+    out.push(line);
+    i++;
+  }
+
+  let geml = out.join("\n");
+  if (!geml.endsWith("\n")) geml += "\n";
+  return { geml, notes };
+}

--- a/geml-parser/src/geml.ts
+++ b/geml-parser/src/geml.ts
@@ -1,31 +1,37 @@
-// GEML reference parser — Milestone 1: block scanner.
+// GEML reference parser — Milestones 1 & 2: block scanner + inline content.
 //
-// Scope: typed-block fences (equal-length close + longer-fence nesting),
-// the `meta` data block, ATX headings, lists and paragraphs, the attribute
-// object with §4 value typing, and a document-model JSON serialization.
-// Inline parsing (§5) and reference validation (§4/§8) arrive in M2.
+// M1: typed-block fences (equal-length close + longer-fence nesting), the
+// `meta` data block, ATX headings, lists and paragraphs, the attribute object
+// with §4 value typing, and a document-model JSON serialization.
+//
+// M2: inline parsing of flow blocks (§5 — emphasis/strong/strike, code, math,
+// media embeds, links, auto-references, footnotes) and build-time reference
+// validation (§8 — unique ids, resolvable internal/cross-document references).
 
 import { readFileSync } from "node:fs";
+import { dirname, resolve as resolvePath } from "node:path";
 import { commit, restore, verify } from "./history.js";
+import { type Value, coerce, parseAttrs } from "./attrs.js";
+import { type Inline, type Ref, type RefSink, parseInline } from "./inline.js";
+
+export { type Value } from "./attrs.js";
+export { type Inline } from "./inline.js";
 
 // ---------------------------------------------------------------------------
 // Model
 // ---------------------------------------------------------------------------
 
-export type Value = string | number | boolean;
-
-export interface Attrs {
-  id?: string;
-  classes: string[];
-  attrs: Record<string, Value>;
-}
-
 export type BodyMode = "raw" | "flow" | "data";
 
+export interface ListItem {
+  text: string;
+  inlines: Inline[];
+}
+
 export type Block =
-  | { kind: "heading"; level: number; text: string; id?: string; classes: string[]; attrs: Record<string, Value> }
-  | { kind: "paragraph"; text: string }
-  | { kind: "list"; ordered: boolean; items: string[] }
+  | { kind: "heading"; level: number; text: string; inlines: Inline[]; id?: string; classes: string[]; attrs: Record<string, Value> }
+  | { kind: "paragraph"; text: string; inlines: Inline[] }
+  | { kind: "list"; ordered: boolean; items: ListItem[] }
   | {
       kind: "block";
       type: string;
@@ -47,7 +53,21 @@ export interface Diagnostic {
 export interface Document {
   kind: "document";
   children: Block[];
+  ids: string[];
   diagnostics: Diagnostic[];
+}
+
+// Optional hook for resolving cross-document references (other.geml#id) at
+// build time. Returns the target file's source, or null if it cannot be found.
+export interface ParseOptions {
+  resolveDoc?: (doc: string) => string | null;
+}
+
+// Parse context threaded through the scanner: diagnostics, the id registry
+// (id -> defining line, for uniqueness), and discovered references.
+interface Ctx extends RefSink {
+  diags: Diagnostic[];
+  ids: Map<string, number>;
 }
 
 // Type registry: which body mode each typed block uses. Unknown types are a
@@ -61,58 +81,6 @@ const REGISTRY: Record<string, BodyMode> = {
   aside: "flow",
   meta: "data",
 };
-
-// ---------------------------------------------------------------------------
-// Value typing (§4)
-// ---------------------------------------------------------------------------
-
-function coerce(raw: string): Value {
-  const t = raw.trim();
-  if (t.length >= 2 && t.startsWith('"') && t.endsWith('"')) {
-    return t.slice(1, -1); // quoted -> always string
-  }
-  if (t === "true") return true;
-  if (t === "false") return false;
-  if (/^[+-]?\d+$/.test(t)) return parseInt(t, 10);
-  if (/^[+-]?(\d+\.\d*|\.\d+|\d+)([eE][+-]?\d+)?$/.test(t) && /[.eE]/.test(t)) return parseFloat(t);
-  return t; // bare word -> string
-}
-
-// Split on whitespace while keeping double-quoted spans intact.
-function tokenize(s: string): string[] {
-  const out: string[] = [];
-  let cur = "";
-  let inQuote = false;
-  for (const ch of s) {
-    if (ch === '"') {
-      inQuote = !inQuote;
-      cur += ch;
-    } else if (!inQuote && /\s/.test(ch)) {
-      if (cur) { out.push(cur); cur = ""; }
-    } else {
-      cur += ch;
-    }
-  }
-  if (cur) out.push(cur);
-  return out;
-}
-
-// Parse `{#id .class key=val key2="a b"}` (braces included).
-function parseAttrs(src: string): Attrs {
-  const inner = src.trim().replace(/^\{/, "").replace(/\}$/, "");
-  const out: Attrs = { classes: [], attrs: {} };
-  for (const tok of tokenize(inner)) {
-    if (tok.startsWith("#")) {
-      out.id = tok.slice(1);
-    } else if (tok.startsWith(".")) {
-      out.classes.push(tok.slice(1));
-    } else {
-      const eq = tok.indexOf("=");
-      if (eq > 0) out.attrs[tok.slice(0, eq)] = coerce(tok.slice(eq + 1));
-    }
-  }
-  return out;
-}
 
 // ---------------------------------------------------------------------------
 // Lexical helpers
@@ -141,8 +109,18 @@ function slug(text: string): string {
 // Block scanner
 // ---------------------------------------------------------------------------
 
-function scanBlocks(lines: string[], base: number, diags: Diagnostic[]): Block[] {
+// Register a block id, flagging duplicates as errors (§4: ids unique per doc).
+function registerId(ctx: Ctx, id: string, line: number): void {
+  if (ctx.ids.has(id)) {
+    ctx.diags.push({ severity: "error", message: `duplicate id \`#${id}\` (first defined at line ${ctx.ids.get(id)})`, line });
+  } else {
+    ctx.ids.set(id, line);
+  }
+}
+
+function scanBlocks(lines: string[], base: number, ctx: Ctx): Block[] {
   const blocks: Block[] = [];
+  const diags = ctx.diags;
   let i = 0;
 
   while (i < lines.length) {
@@ -178,10 +156,10 @@ function scanBlocks(lines: string[], base: number, diags: Diagnostic[]): Block[]
       const block: Extract<Block, { kind: "block" }> = {
         kind: "block", type, mode, classes: attrs.classes, attrs: attrs.attrs,
       };
-      if (attrs.id !== undefined) block.id = attrs.id;
+      if (attrs.id !== undefined) { block.id = attrs.id; registerId(ctx, attrs.id, openLineNo); }
 
       if (mode === "flow") {
-        block.children = scanBlocks(body, base + i + 1, diags);
+        block.children = scanBlocks(body, base + i + 1, ctx);
       } else if (mode === "data") {
         block.data = parseData(body);
       } else {
@@ -195,11 +173,14 @@ function scanBlocks(lines: string[], base: number, diags: Diagnostic[]): Block[]
 
     const h = HEADING.exec(line);
     if (h) {
+      const lineNo = base + i + 1;
       const level = h[1]!.length;
       const text = h[2]!;
       const a = h[3] ? parseAttrs(h[3]) : { classes: [], attrs: {} };
+      const id = a.id ?? slug(text);
+      registerId(ctx, id, lineNo);
       const block: Extract<Block, { kind: "heading" }> = {
-        kind: "heading", level, text, id: a.id ?? slug(text), classes: a.classes, attrs: a.attrs,
+        kind: "heading", level, text, inlines: parseInline(text, lineNo, ctx), id, classes: a.classes, attrs: a.attrs,
       };
       blocks.push(block);
       i++;
@@ -208,9 +189,10 @@ function scanBlocks(lines: string[], base: number, diags: Diagnostic[]): Block[]
 
     if (LIST_ITEM.test(line)) {
       const ordered = ORDERED_ITEM.test(line);
-      const items: string[] = [];
+      const items: ListItem[] = [];
       while (i < lines.length && LIST_ITEM.test(lines[i]!)) {
-        items.push(LIST_ITEM.exec(lines[i]!)![1]!);
+        const text = LIST_ITEM.exec(lines[i]!)![1]!;
+        items.push({ text, inlines: parseInline(text, base + i + 1, ctx) });
         i++;
       }
       blocks.push({ kind: "list", ordered, items });
@@ -218,6 +200,7 @@ function scanBlocks(lines: string[], base: number, diags: Diagnostic[]): Block[]
     }
 
     // Paragraph: consecutive non-blank lines that start no other construct.
+    const paraStart = base + i + 1;
     const para: string[] = [];
     while (
       i < lines.length &&
@@ -229,7 +212,8 @@ function scanBlocks(lines: string[], base: number, diags: Diagnostic[]): Block[]
       para.push(lines[i]!);
       i++;
     }
-    blocks.push({ kind: "paragraph", text: para.join("\n") });
+    const text = para.join("\n");
+    blocks.push({ kind: "paragraph", text, inlines: parseInline(text, paraStart, ctx) });
   }
 
   return blocks;
@@ -251,11 +235,56 @@ function parseData(lines: string[]): Record<string, Value> {
 // Public API
 // ---------------------------------------------------------------------------
 
-export function parse(source: string): Document {
-  const diagnostics: Diagnostic[] = [];
+// Collect the block ids of a (cross-document) source, without validation, for
+// resolving `other.geml#id` references.
+function gatherIds(source: string): Set<string> {
+  const ctx: Ctx = { diags: [], ids: new Map(), refs: [] };
+  scanBlocks(source.replace(/\r\n?/g, "\n").split("\n"), 0, ctx);
+  return new Set(ctx.ids.keys());
+}
+
+// §8: resolve every discovered reference. Internal/autoref/footnote anchors
+// must exist in this document; cross-document anchors must resolve in the
+// target file when a `resolveDoc` hook is supplied (else reported as unchecked).
+function validateRefs(ctx: Ctx, opts: ParseOptions): void {
+  const docIds = new Map<string, Set<string>>(); // memoized cross-doc id sets
+  for (const ref of ctx.refs) {
+    if (ref.kind === "cross") {
+      if (!ref.doc) continue;
+      if (!opts.resolveDoc) {
+        ctx.diags.push({ severity: "warning", message: `cross-document reference \`${ref.doc}${ref.anchor ? "#" + ref.anchor : ""}\` not checked (no document resolver)`, line: ref.line });
+        continue;
+      }
+      let ids = docIds.get(ref.doc);
+      if (ids === undefined) {
+        const src = opts.resolveDoc(ref.doc);
+        if (src === null) {
+          ctx.diags.push({ severity: "error", message: `cannot resolve document \`${ref.doc}\``, line: ref.line });
+          docIds.set(ref.doc, new Set());
+          continue;
+        }
+        ids = gatherIds(src);
+        docIds.set(ref.doc, ids);
+      }
+      if (ref.anchor !== undefined && !ids.has(ref.anchor)) {
+        ctx.diags.push({ severity: "error", message: `unresolved reference \`${ref.doc}#${ref.anchor}\``, line: ref.line });
+      }
+      continue;
+    }
+    // internal, autoref, footnote — anchor must be a known id in this document.
+    if (ref.anchor !== undefined && !ctx.ids.has(ref.anchor)) {
+      const what = ref.kind === "footnote" ? `footnote \`[^${ref.anchor}]\`` : `reference \`#${ref.anchor}\``;
+      ctx.diags.push({ severity: "error", message: `unresolved ${what}`, line: ref.line });
+    }
+  }
+}
+
+export function parse(source: string, opts: ParseOptions = {}): Document {
+  const ctx: Ctx = { diags: [], ids: new Map(), refs: [] };
   const lines = source.replace(/\r\n?/g, "\n").split("\n");
-  const children = scanBlocks(lines, 0, diagnostics);
-  return { kind: "document", children, diagnostics };
+  const children = scanBlocks(lines, 0, ctx);
+  validateRefs(ctx, opts);
+  return { kind: "document", children, ids: [...ctx.ids.keys()], diagnostics: ctx.diags };
 }
 
 // ---------------------------------------------------------------------------
@@ -329,7 +358,13 @@ if (entry.endsWith("geml.js") || entry.endsWith("geml.ts")) {
       console.error("usage: geml <file.geml> | geml history <commit|verify|show|restore> <file.geml> [...]");
       process.exit(2);
     }
-    const doc = parse(readFileSync(file, "utf8"));
+    const baseDir = dirname(file);
+    const doc = parse(readFileSync(file, "utf8"), {
+      resolveDoc: (d) => {
+        try { return readFileSync(resolvePath(baseDir, d), "utf8"); }
+        catch { return null; }
+      },
+    });
     console.log(JSON.stringify(doc, null, 2));
     if (doc.diagnostics.some((d) => d.severity === "error")) process.exit(1);
   }

--- a/geml-parser/src/geml.ts
+++ b/geml-parser/src/geml.ts
@@ -12,10 +12,12 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve as resolvePath } from "node:path";
 import { commit, restore, verify } from "./history.js";
 import { type Value, coerce, parseAttrs } from "./attrs.js";
-import { type Inline, type Ref, type RefSink, parseInline } from "./inline.js";
+import { type Inline, type RefSink, parseInline } from "./inline.js";
+import { type TableModel, parseTable } from "./table.js";
 
 export { type Value } from "./attrs.js";
 export { type Inline } from "./inline.js";
+export { type TableModel } from "./table.js";
 
 // ---------------------------------------------------------------------------
 // Model
@@ -42,6 +44,7 @@ export type Block =
       raw?: string[];
       children?: Block[];
       data?: Record<string, Value>;
+      table?: TableModel;
     };
 
 export interface Diagnostic {
@@ -81,6 +84,10 @@ const REGISTRY: Record<string, BodyMode> = {
   aside: "flow",
   meta: "data",
 };
+
+// §7: built-in diagram renderer registry. Unknown formats are a warning (the
+// processor keeps the body raw rather than interpreting it).
+const DIAGRAM_RENDERERS = new Set(["mermaid", "graphviz", "dot", "d2", "plantuml"]);
 
 // ---------------------------------------------------------------------------
 // Lexical helpers
@@ -164,6 +171,18 @@ function scanBlocks(lines: string[], base: number, ctx: Ctx): Block[] {
         block.data = parseData(body);
       } else {
         block.raw = body;
+        if (type === "table") {
+          // §6: parse the raw body (visual or csv/tsv) into one table model.
+          const { model, diagnostics } = parseTable(body, attrs.attrs, openLineNo, ctx);
+          block.table = model;
+          for (const d of diagnostics) diags.push({ ...d, line: openLineNo });
+        } else if (type === "diagram") {
+          // §7: warn on a diagram format with no registered renderer.
+          const fmt = attrs.attrs["format"];
+          if (typeof fmt === "string" && !DIAGRAM_RENDERERS.has(fmt)) {
+            diags.push({ severity: "warning", message: `no registered renderer for diagram format \`${fmt}\`; body kept raw`, line: openLineNo });
+          }
+        }
       }
 
       blocks.push(block);

--- a/geml-parser/src/geml.ts
+++ b/geml-parser/src/geml.ts
@@ -8,16 +8,18 @@
 // media embeds, links, auto-references, footnotes) and build-time reference
 // validation (§8 — unique ids, resolvable internal/cross-document references).
 
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve as resolvePath } from "node:path";
 import { commit, restore, verify } from "./history.js";
 import { type Value, coerce, parseAttrs } from "./attrs.js";
 import { type Inline, type RefSink, parseInline } from "./inline.js";
 import { type TableModel, parseTable } from "./table.js";
+import { mdToGeml } from "./from-md.js";
 
 export { type Value } from "./attrs.js";
 export { type Inline } from "./inline.js";
 export { type TableModel } from "./table.js";
+export { mdToGeml, type ConvertResult } from "./from-md.js";
 
 // ---------------------------------------------------------------------------
 // Model
@@ -366,11 +368,31 @@ function runHistory(args: string[]): void {
   }
 }
 
+// `geml convert <file.md> [-o out.geml]` — Markdown -> GEML.
+function runConvert(args: string[]): void {
+  const file = args.find((a) => !a.startsWith("-") && a !== flag(args, "-o"));
+  if (!file) {
+    console.error("usage: geml convert <file.md> [-o out.geml]");
+    process.exit(2);
+  }
+  const { geml, notes } = mdToGeml(readFileSync(file, "utf8"));
+  for (const n of notes) console.error(`note: ${n}`);
+  const outPath = flag(args, "-o") ?? flag(args, "--out");
+  if (outPath) {
+    writeFileSync(outPath, geml);
+    console.error(`wrote ${outPath}`);
+  } else {
+    process.stdout.write(geml);
+  }
+}
+
 const entry = process.argv[1] ?? "";
 if (entry.endsWith("geml.js") || entry.endsWith("geml.ts")) {
   const argv = process.argv.slice(2);
   if (argv[0] === "history") {
     runHistory(argv.slice(1));
+  } else if (argv[0] === "convert") {
+    runConvert(argv.slice(1));
   } else {
     const file = argv[0];
     if (!file) {

--- a/geml-parser/src/inline.ts
+++ b/geml-parser/src/inline.ts
@@ -1,0 +1,277 @@
+// GEML reference parser — Milestone 2: inline content (§5).
+//
+// Parses the inline grammar of flow blocks (paragraphs, headings, list items):
+// escapes, code spans, inline math, images, links, auto-references, footnote
+// references, then emphasis/strong/strike — in the §5.3 priority order. Every
+// internal/cross-document reference is reported to a `RefSink` so the document
+// layer can resolve and validate it at build time (§8).
+
+import { type Value, parseAttrs } from "./attrs.js";
+
+export type Inline =
+  | { type: "text"; value: string }
+  | { type: "emph"; children: Inline[] }
+  | { type: "strong"; children: Inline[] }
+  | { type: "strike"; children: Inline[] }
+  | { type: "code"; value: string }
+  | { type: "math"; value: string }
+  | { type: "break" }
+  | { type: "image"; alt: string; src: string; as?: string; attrs: Record<string, Value> }
+  | {
+      type: "link";
+      children: Inline[];
+      href?: string;        // external target (scheme://… or mailto:)
+      doc?: string;         // cross-document target (other.geml)
+      anchor?: string;      // block id within doc (or this file when doc absent)
+      attrs: Record<string, Value>;
+    }
+  | { type: "autoref"; anchor: string; doc?: string }
+  | { type: "footnote"; ref: string };
+
+// A reference discovered during inline parsing, to be resolved by §8.
+export interface Ref {
+  // "internal": #anchor in this file; "cross": other.geml(#anchor)?;
+  // "footnote": [^id]; "autoref": [[#id]] (internal) — all build-time checked.
+  kind: "internal" | "cross" | "footnote" | "autoref";
+  doc?: string;
+  anchor?: string;
+  line: number;
+}
+
+export interface RefSink {
+  refs: Ref[];
+}
+
+const SCHEME = /^[a-z][a-z0-9+.-]*:/i; // http:, https:, mailto:, …
+
+// Classify a link/image destination into {href|doc, anchor}.
+function classifyDest(dest: string): { href?: string; doc?: string; anchor?: string } {
+  const d = dest.trim();
+  if (SCHEME.test(d)) return { href: d };
+  const hash = d.indexOf("#");
+  if (hash === 0) return { anchor: d.slice(1) };
+  if (hash > 0) return { doc: d.slice(0, hash), anchor: d.slice(hash + 1) };
+  if (d) return { doc: d };
+  return {};
+}
+
+// Read a balanced `(...)` starting at s[i]==='('. Returns content and index
+// just past the closing ')', or null if unbalanced.
+function readParen(s: string, i: number): { content: string; end: number } | null {
+  if (s[i] !== "(") return null;
+  let depth = 0;
+  for (let j = i; j < s.length; j++) {
+    const c = s[j];
+    if (c === "(") depth++;
+    else if (c === ")") {
+      depth--;
+      if (depth === 0) return { content: s.slice(i + 1, j), end: j + 1 };
+    }
+  }
+  return null;
+}
+
+// Read a balanced `[...]` starting at s[i]==='['. Returns content and index
+// just past the closing ']', or null if unbalanced.
+function readBracket(s: string, i: number): { content: string; end: number } | null {
+  if (s[i] !== "[") return null;
+  let depth = 0;
+  for (let j = i; j < s.length; j++) {
+    const c = s[j];
+    if (c === "[") depth++;
+    else if (c === "]") {
+      depth--;
+      if (depth === 0) return { content: s.slice(i + 1, j), end: j + 1 };
+    }
+  }
+  return null;
+}
+
+// Optional `{…}` attribute object immediately following a construct.
+function readAttrs(s: string, i: number): { attrs: ReturnType<typeof parseAttrs>; end: number } | null {
+  if (s[i] !== "{") return null;
+  const close = s.indexOf("}", i);
+  if (close < 0) return null;
+  return { attrs: parseAttrs(s.slice(i, close + 1)), end: close + 1 };
+}
+
+// Phase A: pull out high-priority atoms (escapes, code, math, media, links,
+// auto-refs, footnotes, hard breaks). Everything else is left as text runs for
+// phase B (emphasis). Children of links are fully re-parsed.
+function scanAtoms(s: string, line: number, sink: RefSink): (string | Inline)[] {
+  const out: (string | Inline)[] = [];
+  let buf = "";
+  const flush = () => { if (buf) { out.push(buf); buf = ""; } };
+  let i = 0;
+
+  while (i < s.length) {
+    const c = s[i]!;
+
+    // §5.3(1): backslash escape / hard break.
+    if (c === "\\") {
+      const next = s[i + 1];
+      if (next === undefined || next === "\n") { // line-final backslash
+        flush();
+        out.push({ type: "break" });
+        i += next === undefined ? 1 : 2;
+        continue;
+      }
+      if (/[!-/:-@[-`{-~]/.test(next)) { // ASCII punctuation -> literal
+        buf += next;
+        i += 2;
+        continue;
+      }
+      buf += c;
+      i++;
+      continue;
+    }
+
+    // §5.3(1): code span — matched by run length, content kept raw.
+    if (c === "`") {
+      let n = 0;
+      while (s[i + n] === "`") n++;
+      const fence = "`".repeat(n);
+      const close = s.indexOf(fence, i + n);
+      if (close >= 0) {
+        flush();
+        out.push({ type: "code", value: s.slice(i + n, close) });
+        i = close + n;
+        continue;
+      }
+      buf += fence;
+      i += n;
+      continue;
+    }
+
+    // §5.3(1): inline math $…$ (raw).
+    if (c === "$") {
+      const close = s.indexOf("$", i + 1);
+      if (close > i + 1) {
+        flush();
+        out.push({ type: "math", value: s.slice(i + 1, close) });
+        i = close + 1;
+        continue;
+      }
+      buf += c;
+      i++;
+      continue;
+    }
+
+    // §5.3(2): image ![alt](src){…}.
+    if (c === "!" && s[i + 1] === "[") {
+      const label = readBracket(s, i + 1);
+      const paren = label ? readParen(s, label.end) : null;
+      if (label && paren) {
+        const a = readAttrs(s, paren.end);
+        const attrObj = a ? a.attrs : { classes: [], attrs: {} };
+        const node: Extract<Inline, { type: "image" }> = {
+          type: "image", alt: label.content, src: paren.content.trim(), attrs: attrObj.attrs,
+        };
+        const as = attrObj.attrs["as"];
+        if (typeof as === "string") node.as = as;
+        flush();
+        out.push(node);
+        i = a ? a.end : paren.end;
+        continue;
+      }
+    }
+
+    // §5.3(2): auto-reference [[#id]].
+    if (c === "[" && s[i + 1] === "[") {
+      const inner = readBracket(s, i + 1); // inner [...] after the first [
+      if (inner && s[inner.end] === "]") {
+        const target = inner.content.trim();
+        const { doc, anchor } = classifyDest(target);
+        if (anchor) {
+          flush();
+          const node: Extract<Inline, { type: "autoref" }> = { type: "autoref", anchor };
+          if (doc) node.doc = doc;
+          out.push(node);
+          sink.refs.push({ kind: doc ? "cross" : "autoref", doc, anchor, line });
+          i = inner.end + 1;
+          continue;
+        }
+      }
+    }
+
+    // §5.3(2): footnote reference [^id].
+    if (c === "[" && s[i + 1] === "^") {
+      const br = readBracket(s, i);
+      if (br && br.content.startsWith("^")) {
+        const ref = br.content.slice(1).trim();
+        flush();
+        out.push({ type: "footnote", ref });
+        sink.refs.push({ kind: "footnote", anchor: ref, line });
+        i = br.end;
+        continue;
+      }
+    }
+
+    // §5.3(2): link [text](dest){…}.
+    if (c === "[") {
+      const label = readBracket(s, i);
+      const paren = label ? readParen(s, label.end) : null;
+      if (label && paren) {
+        const a = readAttrs(s, paren.end);
+        const attrObj = a ? a.attrs : { classes: [], attrs: {} };
+        const dest = classifyDest(paren.content);
+        const node: Extract<Inline, { type: "link" }> = {
+          type: "link",
+          children: parseInline(label.content, line, sink),
+          attrs: attrObj.attrs,
+        };
+        if (dest.href) node.href = dest.href;
+        if (dest.doc) node.doc = dest.doc;
+        if (dest.anchor) node.anchor = dest.anchor;
+        if (dest.anchor || dest.doc) {
+          sink.refs.push({ kind: dest.doc ? "cross" : "internal", doc: dest.doc, anchor: dest.anchor, line });
+        }
+        flush();
+        out.push(node);
+        i = a ? a.end : paren.end;
+        continue;
+      }
+    }
+
+    buf += c;
+    i++;
+  }
+  flush();
+  return out;
+}
+
+// Phase B: emphasis / strong / strike on a plain text run (§5.3(3)). Strong and
+// strike bind before emphasis; delimiters must hug non-space characters.
+const EMPH_PATTERNS: { re: RegExp; type: "strong" | "strike" | "emph" }[] = [
+  { re: /\*\*(\S(?:[\s\S]*?\S)?)\*\*/, type: "strong" },
+  { re: /~~(\S(?:[\s\S]*?\S)?)~~/, type: "strike" },
+  { re: /\*(\S(?:[\s\S]*?\S)?)\*/, type: "emph" },
+];
+
+function emphasize(text: string, line: number, sink: RefSink): Inline[] {
+  let best: { idx: number; m: RegExpExecArray; type: "strong" | "strike" | "emph" } | null = null;
+  for (const p of EMPH_PATTERNS) {
+    const m = p.re.exec(text);
+    if (m && (best === null || m.index < best.idx)) best = { idx: m.index, m, type: p.type };
+  }
+  if (!best) return text ? [{ type: "text", value: text }] : [];
+
+  const { m, type } = best;
+  const left = text.slice(0, m.index);
+  const right = text.slice(m.index + m[0].length);
+  const out: Inline[] = [];
+  if (left) out.push({ type: "text", value: left });
+  out.push({ type, children: emphasize(m[1]!, line, sink) } as Inline);
+  out.push(...emphasize(right, line, sink));
+  return out;
+}
+
+export function parseInline(s: string, line: number, sink: RefSink): Inline[] {
+  const atoms = scanAtoms(s, line, sink);
+  const out: Inline[] = [];
+  for (const a of atoms) {
+    if (typeof a === "string") out.push(...emphasize(a, line, sink));
+    else out.push(a);
+  }
+  return out;
+}

--- a/geml-parser/src/table.ts
+++ b/geml-parser/src/table.ts
@@ -1,0 +1,315 @@
+// GEML reference parser — Milestone 3: tables (§6).
+//
+// A `table` block has two interchangeable body forms that parse to the SAME
+// model: a visual pipe grid, or a data form (`format=csv`/`tsv`). The model
+// carries column names, per-column alignment, body cells (inline-parsed),
+// merged-cell spans (`span="r2c1:2x1"`), and columns produced by `compute`
+// formulas (per-row arithmetic over columns, with sum/avg/min/max/count
+// aggregates). See §6.
+
+import { type Value, coerce } from "./attrs.js";
+import { type Inline, type RefSink, parseInline } from "./inline.js";
+
+export type Align = "left" | "right" | "center";
+
+export interface TableCell {
+  text: string;
+  inlines: Inline[];
+  align?: Align;
+  value?: number;     // numeric value, when the cell is/becomes a number
+  computed?: boolean; // produced by a `compute` formula
+  span?: { rows: number; cols: number };
+}
+
+export interface TableModel {
+  caption?: string;
+  header: boolean;
+  columns: string[];                 // header names (or letters A,B,… if none)
+  align: (Align | undefined)[];
+  rows: TableCell[][];               // body rows (header excluded)
+}
+
+export interface TableDiag { severity: "error" | "warning"; message: string; }
+
+export interface TableResult {
+  model: TableModel;
+  diagnostics: TableDiag[];
+}
+
+// ---------------------------------------------------------------------------
+// Body-form parsing
+// ---------------------------------------------------------------------------
+
+const SEP_CELL = /^:?-+:?$/;
+
+function alignOf(sep: string): Align | undefined {
+  const l = sep.startsWith(":");
+  const r = sep.endsWith(":");
+  if (l && r) return "center";
+  if (r) return "right";
+  if (l) return "left";
+  return undefined;
+}
+
+// Split a visual table row `| a | b |` into trimmed cell strings.
+function splitPipes(line: string): string[] {
+  let s = line.trim();
+  if (s.startsWith("|")) s = s.slice(1);
+  if (s.endsWith("|")) s = s.slice(0, -1);
+  return s.split("|").map((c) => c.trim());
+}
+
+function parseVisual(body: string[]): { columns: string[]; align: (Align | undefined)[]; header: boolean; cells: string[][] } {
+  const rows = body.filter((l) => l.trim() !== "").map(splitPipes);
+  let sepIdx = -1;
+  for (let r = 0; r < rows.length; r++) {
+    if (rows[r]!.length > 0 && rows[r]!.every((c) => SEP_CELL.test(c))) { sepIdx = r; break; }
+  }
+  if (sepIdx >= 0) {
+    const headerRow = sepIdx > 0 ? rows[sepIdx - 1]! : [];
+    const align = rows[sepIdx]!.map(alignOf);
+    const cells = rows.slice(sepIdx + 1);
+    const columns = headerRow.length ? headerRow : letters(cells[0]?.length ?? align.length);
+    return { columns, align, header: headerRow.length > 0, cells };
+  }
+  // No separator: headerless, columns are letters.
+  const width = rows.reduce((m, r) => Math.max(m, r.length), 0);
+  return { columns: letters(width), align: [], header: false, cells: rows };
+}
+
+function parseDelimited(body: string[], sep: string, header: boolean): { columns: string[]; align: (Align | undefined)[]; header: boolean; cells: string[][] } {
+  const rows = body.filter((l) => l.trim() !== "").map((l) => l.split(sep).map((c) => c.trim()));
+  if (header && rows.length) {
+    return { columns: rows[0]!, align: [], header: true, cells: rows.slice(1) };
+  }
+  const width = rows.reduce((m, r) => Math.max(m, r.length), 0);
+  return { columns: letters(width), align: [], header: false, cells: rows };
+}
+
+function letters(n: number): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < n; i++) out.push(String.fromCharCode(65 + i));
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// `compute` formulas (§6)
+// ---------------------------------------------------------------------------
+
+type ColResolve = (name: string, row: number) => number | null;
+
+const AGGS = new Set(["sum", "avg", "min", "max", "count"]);
+
+interface Tok { t: "num" | "name" | "op" | "lp" | "rp" | "comma"; v: string; }
+
+function lexExpr(s: string): Tok[] {
+  const out: Tok[] = [];
+  let i = 0;
+  while (i < s.length) {
+    const c = s[i]!;
+    if (/\s/.test(c)) { i++; continue; }
+    if ("+-*/".includes(c)) { out.push({ t: "op", v: c }); i++; continue; }
+    if (c === "(") { out.push({ t: "lp", v: c }); i++; continue; }
+    if (c === ")") { out.push({ t: "rp", v: c }); i++; continue; }
+    if (c === ",") { out.push({ t: "comma", v: c }); i++; continue; }
+    if (/[0-9.]/.test(c)) {
+      let j = i; while (j < s.length && /[0-9.]/.test(s[j]!)) j++;
+      out.push({ t: "num", v: s.slice(i, j) }); i = j; continue;
+    }
+    // identifier: column name or function — run of non-operator chars
+    let j = i;
+    while (j < s.length && !/[\s+\-*/(),]/.test(s[j]!)) j++;
+    out.push({ t: "name", v: s.slice(i, j) }); i = j;
+  }
+  return out;
+}
+
+// Recursive-descent evaluator restricted to + - * / ( ) and aggregate funcs.
+function evalExpr(toks: Tok[], row: number, col: ColResolve, agg: (fn: string, name: string) => number | null): number {
+  let p = 0;
+  const peek = () => toks[p];
+  const next = () => toks[p++]!;
+
+  function parseExpr(): number {
+    let v = parseTerm();
+    while (peek() && peek()!.t === "op" && (peek()!.v === "+" || peek()!.v === "-")) {
+      const op = next().v;
+      const r = parseTerm();
+      v = op === "+" ? v + r : v - r;
+    }
+    return v;
+  }
+  function parseTerm(): number {
+    let v = parseFactor();
+    while (peek() && peek()!.t === "op" && (peek()!.v === "*" || peek()!.v === "/")) {
+      const op = next().v;
+      const r = parseFactor();
+      v = op === "*" ? v * r : v / r;
+    }
+    return v;
+  }
+  function parseFactor(): number {
+    const tk = peek();
+    if (!tk) throw new Error("unexpected end of formula");
+    if (tk.t === "op" && tk.v === "-") { next(); return -parseFactor(); }
+    if (tk.t === "lp") { next(); const v = parseExpr(); if (peek()?.t !== "rp") throw new Error("missing )"); next(); return v; }
+    if (tk.t === "num") { next(); return parseFloat(tk.v); }
+    if (tk.t === "name") {
+      next();
+      if (peek()?.t === "lp" && AGGS.has(tk.v.toLowerCase())) {
+        next();
+        const arg = peek();
+        if (arg?.t !== "name") throw new Error(`bad argument to ${tk.v}()`);
+        next();
+        if (peek()?.t !== "rp") throw new Error("missing )");
+        next();
+        const a = agg(tk.v.toLowerCase(), arg.v);
+        if (a === null) throw new Error(`unknown column \`${arg.v}\``);
+        return a;
+      }
+      const cv = col(tk.v, row);
+      if (cv === null) throw new Error(`unknown column \`${tk.v}\``);
+      return cv;
+    }
+    throw new Error(`unexpected token \`${tk.v}\``);
+  }
+
+  const v = parseExpr();
+  if (p !== toks.length) throw new Error("trailing tokens in formula");
+  return v;
+}
+
+// ---------------------------------------------------------------------------
+// Spans
+// ---------------------------------------------------------------------------
+
+// Parse `r2c1:2x1` → target cell (1-based row/col over body) + size.
+function parseSpan(s: string): { row: number; col: number; rows: number; cols: number } | null {
+  const m = /^r(\d+)c(\d+):(\d+)x(\d+)$/.exec(s.trim());
+  if (!m) return null;
+  return { row: +m[1]!, col: +m[2]!, rows: +m[3]!, cols: +m[4]! };
+}
+
+// ---------------------------------------------------------------------------
+// Public entry
+// ---------------------------------------------------------------------------
+
+export function parseTable(
+  body: string[],
+  attrs: Record<string, Value>,
+  line: number,
+  sink: RefSink,
+): TableResult {
+  const diagnostics: TableDiag[] = [];
+  const fmt = typeof attrs["format"] === "string" ? (attrs["format"] as string) : undefined;
+
+  let raw: { columns: string[]; align: (Align | undefined)[]; header: boolean; cells: string[][] };
+  if (fmt === "csv" || fmt === "tsv") {
+    const headerAttr = attrs["header"];
+    const header = headerAttr === undefined ? true : headerAttr === true || headerAttr === 1 || headerAttr === "1";
+    raw = parseDelimited(body, fmt === "tsv" ? "\t" : ",", header);
+  } else {
+    if (fmt !== undefined) diagnostics.push({ severity: "warning", message: `unknown table format \`${fmt}\`; parsed as visual grid` });
+    raw = parseVisual(body);
+  }
+
+  const columns = [...raw.columns];
+  const model: TableModel = { header: raw.header, columns, align: raw.align, rows: [] };
+  const caption = attrs["caption"];
+  if (typeof caption === "string") model.caption = caption;
+
+  // Build body cells with inline content and numeric values.
+  for (const r of raw.cells) {
+    const row: TableCell[] = [];
+    for (let c = 0; c < columns.length; c++) {
+      const text = r[c] ?? "";
+      const cell: TableCell = { text, inlines: parseInline(text, line, sink) };
+      const align = raw.align[c];
+      if (align) cell.align = align;
+      const v = coerce(text);
+      if (typeof v === "number") cell.value = v;
+      row.push(cell);
+    }
+    model.rows.push(row);
+  }
+
+  // Column lookup by header name or single letter (A=0).
+  const colIndex = (name: string): number => {
+    const byName = columns.indexOf(name);
+    if (byName >= 0) return byName;
+    if (/^[A-Z]$/.test(name)) return name.charCodeAt(0) - 65;
+    return -1;
+  };
+  const cellNum = (ci: number, row: number): number | null => {
+    const v = model.rows[row]?.[ci]?.value;
+    return typeof v === "number" ? v : null;
+  };
+  const colResolve: ColResolve = (name, row) => {
+    const ci = colIndex(name);
+    return ci < 0 ? null : cellNum(ci, row);
+  };
+  const aggResolve = (fn: string, name: string): number | null => {
+    const ci = colIndex(name);
+    if (ci < 0) return null;
+    const vals: number[] = [];
+    for (let r = 0; r < model.rows.length; r++) { const v = cellNum(ci, r); if (v !== null) vals.push(v); }
+    if (fn === "count") return vals.length;
+    if (vals.length === 0) return 0;
+    if (fn === "sum") return vals.reduce((a, b) => a + b, 0);
+    if (fn === "avg") return vals.reduce((a, b) => a + b, 0) / vals.length;
+    if (fn === "min") return Math.min(...vals);
+    if (fn === "max") return Math.max(...vals);
+    return null;
+  };
+
+  // `compute="Name = expr"` — may appear once or as compute, compute2, …
+  const formulas = Object.entries(attrs)
+    .filter(([k]) => k === "compute" || /^compute\d+$/.test(k))
+    .map(([, v]) => v)
+    .filter((v): v is string => typeof v === "string");
+
+  for (const f of formulas) {
+    const eq = f.indexOf("=");
+    if (eq <= 0) { diagnostics.push({ severity: "error", message: `bad compute formula \`${f}\` (want \`Name = expr\`)` }); continue; }
+    const name = f.slice(0, eq).trim();
+    const expr = f.slice(eq + 1).trim();
+    let toks: Tok[];
+    try { toks = lexExpr(expr); } catch { diagnostics.push({ severity: "error", message: `cannot lex formula \`${f}\`` }); continue; }
+
+    // Target is a header name (never a letter reference): match by name only.
+    let ci = columns.indexOf(name);
+    if (ci < 0) { columns.push(name); ci = columns.length - 1; }
+
+    let failed = false;
+    for (let r = 0; r < model.rows.length && !failed; r++) {
+      try {
+        const v = evalExpr(toks, r, colResolve, aggResolve);
+        const cell = ensureCell(model.rows[r]!, ci);
+        if (Number.isFinite(v)) { cell.value = v; cell.text = String(v); cell.computed = true; cell.inlines = [{ type: "text", value: String(v) }]; }
+      } catch (e) {
+        diagnostics.push({ severity: "error", message: `compute \`${name}\`: ${(e as Error).message}` });
+        failed = true;
+      }
+    }
+  }
+
+  // Spans: `span="r2c1:2x1"` (one or many: span, span2, …).
+  const spanDecls = Object.entries(attrs)
+    .filter(([k]) => k === "span" || /^span\d+$/.test(k))
+    .map(([, v]) => v)
+    .filter((v): v is string => typeof v === "string");
+  for (const sd of spanDecls) {
+    const sp = parseSpan(sd);
+    if (!sp) { diagnostics.push({ severity: "error", message: `bad span \`${sd}\` (want \`rNcM:RxC\`)` }); continue; }
+    const cell = model.rows[sp.row - 1]?.[sp.col - 1];
+    if (!cell) { diagnostics.push({ severity: "warning", message: `span \`${sd}\` targets a cell outside the table` }); continue; }
+    cell.span = { rows: sp.rows, cols: sp.cols };
+  }
+
+  return { model, diagnostics };
+}
+
+function ensureCell(row: TableCell[], ci: number): TableCell {
+  while (row.length <= ci) row.push({ text: "", inlines: [] });
+  return row[ci]!;
+}

--- a/geml-parser/test/convert.test.mjs
+++ b/geml-parser/test/convert.test.mjs
@@ -1,0 +1,64 @@
+// Markdown -> GEML conversion checks. Run with `npm test`.
+import { mdToGeml, parse } from "../dist/geml.js";
+import { strict as assert } from "node:assert";
+
+let passed = 0;
+function test(name, fn) { fn(); passed++; console.log("ok", name); }
+
+const conv = (md) => mdToGeml(md).geml;
+
+test("YAML frontmatter -> === meta", () => {
+  const g = conv("---\ntitle: My Doc\ndraft: true\nn: 2\n---\n\nbody\n");
+  assert.match(g, /=== meta/);
+  assert.match(g, /title="My Doc"/);
+  assert.match(g, /draft=true/);
+  assert.match(g, /n=2/);
+});
+
+test("fenced code -> === code {lang=…}", () => {
+  const g = conv("```python\nx = 1\n```\n");
+  assert.match(g, /=== code \{lang=python\}/);
+  assert.match(g, /x = 1/);
+});
+
+test("fence grows past `===` lines in the body", () => {
+  const g = conv("```\na\n===\nb\n```\n");
+  assert.match(g, /^==== code/m); // longer fence to clear the body's ===
+});
+
+test("blockquote -> === note", () => {
+  const g = conv("> line one\n> line two\n");
+  assert.match(g, /=== note\nline one\nline two\n===/);
+});
+
+test("GFM table -> === table (visual body)", () => {
+  const g = conv("| A | B |\n|---|--:|\n| 1 | 2 |\n");
+  assert.match(g, /=== table\n\| A \| B \|/);
+  const t = parse(g).children[0].table;
+  assert.deepEqual(t.columns, ["A", "B"]);
+  assert.equal(t.align[1], "right");
+});
+
+test("setext headings -> ATX", () => {
+  const g = conv("Title\n=====\n\nSub\n---\n");
+  assert.match(g, /^# Title$/m);
+  assert.match(g, /^## Sub$/m);
+});
+
+test("display math -> === math", () => {
+  assert.match(conv("$$\nE=mc^2\n$$\n"), /=== math\nE=mc\^2\n===/);
+});
+
+test("thematic break is dropped with a note", () => {
+  const r = mdToGeml("a\n\n---\n\nb\n");
+  assert.doesNotMatch(r.geml, /^---$/m);
+  assert.ok(r.notes.some((n) => /thematic break/.test(n)));
+});
+
+test("converted Markdown round-trips through the parser cleanly", () => {
+  const md = "---\ntitle: T\n---\n\n## H {#h}\n\nText [link](#h) and `code`.\n\n```js\n1\n```\n\n| X | Y |\n|---|---|\n| 1 | 2 |\n";
+  const doc = parse(conv(md));
+  assert.equal(doc.diagnostics.filter((d) => d.severity === "error").length, 0, JSON.stringify(doc.diagnostics));
+});
+
+console.log(`\n${passed} test(s) passed.`);

--- a/geml-parser/test/m2.test.mjs
+++ b/geml-parser/test/m2.test.mjs
@@ -1,0 +1,65 @@
+// M2 conformance checks: inline parsing (§5) and reference validation (§8).
+// Run with `npm test` (after `npm run build`).
+import { parse } from "../dist/geml.js";
+import { strict as assert } from "node:assert";
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log("ok", name);
+}
+
+const types = (inlines) => inlines.map((n) => n.type);
+const errors = (d) => d.diagnostics.filter((x) => x.severity === "error");
+
+test("inline element kinds (§5.1)", () => {
+  const d = parse("Hello **bold** and *em* and `x=1` and ~~no~~ and $a^2$.");
+  const t = types(d.children[0].inlines);
+  for (const k of ["strong", "emph", "code", "strike", "math"]) assert.ok(t.includes(k), `missing ${k}`);
+});
+
+test("code/math bodies are kept raw (§5.3)", () => {
+  const d = parse("`*not emphasis*` and $*not either*$");
+  const [code, , math] = d.children[0].inlines;
+  assert.equal(code.value, "*not emphasis*");
+  assert.equal(math.value, "*not either*");
+});
+
+test("hard break and escapes (§5.1)", () => {
+  const d = parse("a\\\nb \\* literal");
+  const t = types(d.children[0].inlines);
+  assert.ok(t.includes("break"));
+  assert.ok(d.children[0].inlines.some((n) => n.type === "text" && n.value.includes("* literal")));
+});
+
+test("media embed with as= (§5.1)", () => {
+  const img = parse("![pic](a.png){as=image}").children[0].inlines[0];
+  assert.equal(img.type, "image");
+  assert.equal(img.src, "a.png");
+  assert.equal(img.as, "image");
+});
+
+test("resolved internal/auto/footnote refs are clean (§5.2)", () => {
+  const d = parse("# Title {#sec}\n\nSee [text](#sec) and [[#sec]] and [^sec].");
+  assert.equal(d.diagnostics.length, 0, JSON.stringify(d.diagnostics));
+});
+
+test("unresolved refs are errors (§8.3)", () => {
+  const d = parse("See [x](#missing) and [[#nope]] and [^gone].");
+  assert.equal(errors(d).length, 3, JSON.stringify(d.diagnostics));
+});
+
+test("duplicate id is an error (§4)", () => {
+  const d = parse("# A {#dup}\n\n# B {#dup}");
+  assert.ok(d.diagnostics.some((x) => /duplicate id/.test(x.message)));
+});
+
+test("cross-doc ref: warns without resolver, validates with one (§8.4)", () => {
+  assert.ok(parse("[a](o.geml#x).").diagnostics.some((x) => x.severity === "warning"));
+  assert.equal(parse("[a](o.geml#x).", { resolveDoc: () => "# H {#x}" }).diagnostics.length, 0);
+  assert.ok(parse("[a](o.geml#x).", { resolveDoc: () => "# H {#y}" }).diagnostics.some((x) => /unresolved reference/.test(x.message)));
+  assert.ok(parse("[a](gone.geml#x).", { resolveDoc: () => null }).diagnostics.some((x) => /cannot resolve document/.test(x.message)));
+});
+
+console.log(`\n${passed} test(s) passed.`);

--- a/geml-parser/test/m3.test.mjs
+++ b/geml-parser/test/m3.test.mjs
@@ -1,0 +1,62 @@
+// M3 conformance checks: tables (§6) and diagram renderer registry (§7).
+// Run with `npm test` (after `npm run build`).
+import { parse } from "../dist/geml.js";
+import { strict as assert } from "node:assert";
+
+let passed = 0;
+function test(name, fn) { fn(); passed++; console.log("ok", name); }
+
+const table = (src) => parse(src).children[0].table;
+const errors = (d) => d.diagnostics.filter((x) => x.severity === "error");
+
+test("visual form: header, alignment, numeric cells (§6a)", () => {
+  const t = table("=== table {caption=\"c\"}\n| Plan | N |\n|------|--:|\n| Org | 1 |\n| Adoc | 2 |\n===");
+  assert.deepEqual(t.columns, ["Plan", "N"]);
+  assert.equal(t.header, true);
+  assert.equal(t.align[1], "right");
+  assert.equal(t.caption, "c");
+  assert.equal(t.rows.length, 2);
+  assert.equal(t.rows[0][1].value, 1);
+});
+
+test("data form: csv + per-row compute (§6b)", () => {
+  const t = table("=== table {format=csv compute=\"Sub = M * R\"}\nName, M, R\nOrg, 1, 30\nAdoc, 2, 30\n===");
+  assert.deepEqual(t.columns, ["Name", "M", "R", "Sub"]);
+  assert.equal(t.rows[0][3].text, "30");
+  assert.equal(t.rows[1][3].value, 60);
+  assert.equal(t.rows[1][3].computed, true);
+});
+
+test("compute by column letter and aggregate (§6)", () => {
+  const t = table("=== table {format=csv compute=\"T = sum(B)\"}\nName, V\na, 10\nb, 20\n===");
+  assert.equal(t.rows[0][2].value, 30);
+  assert.equal(t.rows[1][2].value, 30);
+});
+
+test("compute precedence and parentheses", () => {
+  const t = table("=== table {format=csv compute=\"X = (A + B) * 2\"}\nA, B\n1, 2\n===");
+  assert.equal(t.rows[0][2].value, 6);
+});
+
+test("compute over unknown column is an error", () => {
+  const d = parse("=== table {format=csv compute=\"X = nope * 2\"}\nA\n1\n===");
+  assert.ok(errors(d).some((e) => /unknown column/.test(e.message)));
+});
+
+test("span declaration attaches to target cell (§6)", () => {
+  const t = table("=== table {format=csv span=\"r1c1:2x1\"}\nName, V\na, 10\nb, 20\n===");
+  assert.deepEqual(t.rows[0][0].span, { rows: 2, cols: 1 });
+});
+
+test("headerless visual form uses letter columns", () => {
+  const t = table("=== table\n| a | b |\n| c | d |\n===");
+  assert.deepEqual(t.columns, ["A", "B"]);
+  assert.equal(t.header, false);
+});
+
+test("unknown diagram format warns, known one is clean (§7)", () => {
+  assert.ok(parse("=== diagram {format=bogus}\nx\n===").diagnostics.some((x) => x.severity === "warning"));
+  assert.equal(parse("=== diagram {format=mermaid}\ngraph LR\n===").diagnostics.length, 0);
+});
+
+console.log(`\n${passed} test(s) passed.`);


### PR DESCRIPTION
This PR implements Milestones 2 and 3 of the GEML reference parser, adding inline content parsing, table support, and Markdown-to-GEML conversion.

## Summary

Extends the parser from block-level scanning (M1) to full document processing with inline content parsing (M2), table parsing and computation (M3), and a Markdown converter. The implementation follows the GEML specification (§5–§8) for inline syntax, tables with computed columns, and reference validation.

## Key Changes

**Inline Parsing (M2, §5)**
- New `inline.ts` module parses inline content: emphasis/strong/strike, code spans, math, images, links, auto-references, and footnotes
- Two-phase approach: atomic elements (code, math, media, links) extracted first, then emphasis applied to remaining text
- All references (internal anchors, cross-document, footnotes) reported to a `RefSink` for build-time validation

**Table Support (M3, §6)**
- New `table.ts` module parses both visual (pipe-delimited) and data (CSV/TSV) table formats into a unified model
- Supports column alignment markers, numeric cell detection, and per-column `compute` formulas with arithmetic and aggregates (sum/avg/min/max/count)
- Merged-cell spans via `span="rNcM:RxC"` declarations
- Formula evaluator with recursive-descent parser for expressions and function calls

**Reference Validation (M2, §8)**
- Block ids registered at parse time; duplicates flagged as errors
- Internal references (#anchor), cross-document references (file.geml#anchor), and footnote references validated
- Optional `resolveDoc` hook for build-time cross-document reference resolution
- Unresolved references produce errors; missing resolver for cross-doc refs produces warnings

**Markdown Conversion**
- New `from-md.ts` module converts Markdown to GEML via block-level mapping:
  - YAML frontmatter → `=== meta` (data block)
  - Fenced code → `=== code {lang=…}` (raw block)
  - Display math → `=== math` (raw block)
  - Blockquotes → `=== note` (flow block)
  - GFM pipe tables → `=== table` (visual body)
  - Setext headings → ATX headings
  - Thematic breaks → dropped with notes
- Inline syntax (emphasis, links, code, etc.) passes through unchanged as it's a Markdown subset

**Attribute Extraction (§4)**
- Moved `coerce`, `tokenize`, and `parseAttrs` to new `attrs.ts` module for reuse across block scanner, inline parser, and table parser
- Supports id, classes, and typed attributes (string/number/boolean)

**Model Updates**
- `Block` now includes `inlines` for parsed inline content in headings and paragraphs
- `ListItem` now carries both raw text and parsed inlines
- `Block` includes optional `table` field for parsed table models
- `Document` now tracks registered ids and includes reference diagnostics

**Testing**
- New test suites: `m2.test.mjs` (inline parsing, reference validation), `m3.test.mjs` (tables, compute, spans), `convert.test.mjs` (Markdown conversion)
- Tests verify inline element kinds, code/math raw content, hard breaks, media embeds, reference resolution, duplicate id detection, table parsing, compute formulas, and round-trip conversion

## Notable Implementation Details

- Formula evaluation uses a recursive-descent parser with operator precedence (addition/subtraction before multiplication/division)
- Emphasis patterns (strong, strike, emph) are applied in priority order to ensure correct binding
- Table fence length automatically grows to exceed any `===` sequences in the body (§3 equal-length close rule)
- Markdown fence detection handles both backticks and tildes with flexible indentation
- Cross-document references default to warning severity without a resolver; validation occurs when resolver is provided

https://claude.ai/code/session_01R8fQ5A5Q3zNfLDza1sZUTu