### PR TITLE
feat(from-md): 支持脚注定义与 autolink；新增元素全覆盖测试

### DIFF
--- a/geml-parser/package.json
+++ b/geml-parser/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "tsc && node test/m2.test.mjs && node test/m3.test.mjs && node test/convert.test.mjs",
+    "test": "tsc && node test/m2.test.mjs && node test/m3.test.mjs && node test/convert.test.mjs && node test/fixtures.test.mjs",
     "convert": "node dist/geml.js convert",
     "parse": "node dist/geml.js"
   },

--- a/geml-parser/src/from-md.ts
+++ b/geml-parser/src/from-md.ts
@@ -51,6 +51,21 @@ function metaLine(line: string): string | null {
   return bareSafe ? `${m[1]}=${v}` : `${m[1]}="${v.replace(/"/g, '\\"')}"`;
 }
 
+// Rewrite Markdown autolinks `<https://…>` / `<mailto:…>` into GEML links
+// `[url](url)` (GEML has no autolink syntax). Inline code spans are left intact.
+function autolinks(s: string): string {
+  return s
+    .split(/(`[^`]*`)/)
+    .map((seg, i) =>
+      i % 2 === 1
+        ? seg
+        : seg
+            .replace(/<((?:https?|ftp):\/\/[^>\s]+)>/g, "[$1]($1)")
+            .replace(/<mailto:([^>\s]+)>/g, "[$1](mailto:$1)"),
+    )
+    .join("");
+}
+
 // GitHub-style heading anchor: drop code backticks (keep content), lowercase,
 // strip punctuation except `-`/`_`, collapse whitespace to hyphens. Used to keep
 // converted headings' ids in sync with Markdown TOC links.
@@ -138,6 +153,23 @@ export function mdToGeml(source: string): ConvertResult {
       continue;
     }
 
+    // Footnote definition `[^id]: body` -> a flow `=== note {#id}` block so the
+    // matching `[^id]` reference resolves at build time (§5.2). Continuation
+    // lines (indented) are folded into the body.
+    const fn = /^\[\^([^\]]+)\]:\s?(.*)$/.exec(line);
+    if (fn) {
+      const body = fn[2]!.trim() ? [fn[2]!.trim()] : [];
+      let j = i + 1;
+      for (; j < lines.length; j++) {
+        if (/^\s{2,}\S/.test(lines[j]!)) body.push(lines[j]!.replace(/^\s+/, ""));
+        else if (lines[j]!.trim() === "") break;
+        else break;
+      }
+      emitBlock(out, "note", `{#${fn[1]!.trim()}}`, body.map(autolinks));
+      i = j;
+      continue;
+    }
+
     // Blockquote -> === note (flow). Strips one `>` level per line.
     if (/^\s*>/.test(line)) {
       const body: string[] = [];
@@ -172,13 +204,16 @@ export function mdToGeml(source: string): ConvertResult {
       if (id) { out.push(`${atx[1]} ${atx[2]} {#${id}}`); i++; continue; }
     }
 
+    // Inline pass: rewrite autolinks to GEML links (outside code spans).
+    const text = autolinks(line);
+
     // Raw HTML note — ignore `<…>` that sits inside an inline code span.
-    if (/<[a-zA-Z/]/.test(line.replace(/`[^`]*`/g, ""))) {
+    if (/<[a-zA-Z/]/.test(text.replace(/`[^`]*`/g, ""))) {
       notes.push(`raw HTML kept as text at line ${i + 1}: ${line.trim().slice(0, 40)}`);
     }
 
     // Everything else (ATX headings, lists, paragraphs, blanks) is valid GEML.
-    out.push(line);
+    out.push(text);
     i++;
   }
 

--- a/geml-parser/test/fixtures.test.mjs
+++ b/geml-parser/test/fixtures.test.mjs
@@ -1,0 +1,54 @@
+// Conversion coverage against larger, element-rich Markdown fixtures.
+// Run with `npm test`.
+import { mdToGeml, parse } from "../dist/geml.js";
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (name) => readFileSync(join(here, "fixtures", name), "utf8");
+
+let passed = 0;
+function test(name, fn) { fn(); passed++; console.log("ok", name); }
+const errors = (d) => d.diagnostics.filter((x) => x.severity === "error");
+
+test("kitchen sink: every construct converts and parses with zero errors", () => {
+  const { geml, notes } = mdToGeml(read("kitchensink.md"));
+  const doc = parse(geml);
+  assert.equal(errors(doc).length, 0, JSON.stringify(doc.diagnostics));
+
+  // YAML frontmatter -> meta
+  const meta = doc.children.find((b) => b.type === "meta");
+  assert.equal(meta.data.version, 3);
+
+  // footnote definition -> a flow note block the [^note] ref resolves to
+  assert.match(geml, /=== note \{#note\}/);
+
+  // autolink -> GEML link
+  assert.match(geml, /\[https:\/\/commonmark\.org\]\(https:\/\/commonmark\.org\)/);
+
+  // GFM column alignment carried into the table model
+  const table = doc.children.find((b) => b.type === "table");
+  assert.deepEqual(table.table.align, ["left", "center", "right"]);
+
+  // embedded GEML example: inner `===` forces a longer outer fence
+  assert.match(geml, /^==== code \{lang=geml\}$/m);
+
+  // only the thematic-break drop is expected as a note
+  assert.ok(notes.every((n) => /thematic break/.test(n)), JSON.stringify(notes));
+});
+
+test("real-world doc: §8 flags dangling links the source relies on", () => {
+  // John Gruber's "Markdown: Syntax" — its TOC points at hand-authored HTML
+  // anchors (#html, #block, …) with no in-document target. Conversion succeeds;
+  // the reference checker correctly reports the dangling links.
+  const { geml } = mdToGeml(read("markdown-syntax.md"));
+  assert.ok(geml.length > 1000);
+  const errs = errors(parse(geml));
+  assert.ok(errs.length >= 10, `expected many dangling refs, got ${errs.length}`);
+  assert.ok(errs.every((e) => /unresolved reference|cannot resolve document/.test(e.message)),
+    errs.map((e) => e.message).join("\n"));
+});
+
+console.log(`\n${passed} test(s) passed.`);

--- a/geml-parser/test/fixtures/kitchensink.md
+++ b/geml-parser/test/fixtures/kitchensink.md
@@ -1,0 +1,98 @@
+---
+title: Kitchen Sink
+author: GEML Test
+draft: false
+version: 3
+---
+
+# Kitchen Sink {#top}
+
+A document exercising as many Markdown constructs as possible.
+
+## Table of Contents {#toc}
+
+1. [Inline formatting](#inline)
+2. [Code](#code)
+3. [Tables](#tables)
+4. [Math](#math)
+5. [Quotes and lists](#quotes-lists)
+6. [Media and links](#media)
+
+Section One
+===========
+
+## Inline formatting {#inline}
+
+Plain text with *emphasis*, **strong**, ***both***, ~~strikethrough~~,
+`inline code`, and inline math $E = mc^2$. A hard break here\
+continues on the next line. Escaped \*asterisks\* stay literal.
+
+A footnote reference[^note] points to a definition below.
+
+Subsection via setext
+---------------------
+
+See [the table section](#tables) and the auto-referenced [[#tables]].
+
+## Code {#code}
+
+```js
+function hello(name) {
+  return `hi ${name}`;
+}
+```
+
+A GEML example embedded as code (note the inner `===` fences):
+
+```geml
+=== table {#demo caption="inner"}
+| a | b |
+|---|---|
+| 1 | 2 |
+===
+```
+
+## Tables {#tables}
+
+| Feature   | Status | Score |
+|:----------|:------:|------:|
+| Headings  |  done  |    10 |
+| Tables    |  done  |     9 |
+| Footnotes |  wip   |     7 |
+
+## Math {#math}
+
+Block math:
+
+$$
+\int_0^1 x^2 \, dx = \frac{1}{3}
+$$
+
+## Quotes and lists {#quotes-lists}
+
+> A blockquote spanning
+> two lines.
+
+- top level
+  - nested item
+  - another nested
+- second top
+  1. ordered child
+  2. ordered child two
+
+Task list:
+
+- [x] done item
+- [ ] pending item
+
+---
+
+## Media and links {#media}
+
+An inline link to [Anthropic](https://www.anthropic.com) and an image:
+
+![alt text](https://example.com/pic.png)
+
+An autolink: <https://commonmark.org>.
+
+[^note]: This is the footnote body.

--- a/geml-parser/test/fixtures/markdown-syntax.md
+++ b/geml-parser/test/fixtures/markdown-syntax.md
@@ -1,0 +1,310 @@
+# Markdown: Syntax
+
+*   [Overview](#overview)
+    *   [Philosophy](#philosophy)
+    *   [Inline HTML](#html)
+    *   [Automatic Escaping for Special Characters](#autoescape)
+*   [Block Elements](#block)
+    *   [Paragraphs and Line Breaks](#p)
+    *   [Headers](#header)
+    *   [Blockquotes](#blockquote)
+    *   [Lists](#list)
+    *   [Code Blocks](#precode)
+    *   [Horizontal Rules](#hr)
+*   [Span Elements](#span)
+    *   [Links](#link)
+    *   [Emphasis](#em)
+    *   [Code](#code)
+    *   [Images](#img)
+*   [Miscellaneous](#misc)
+    *   [Backslash Escapes](#backslash)
+    *   [Automatic Links](#autolink)
+
+
+**Note:** This document is itself written using Markdown; you
+can [see the source for it by adding '.text' to the URL](/projects/markdown/syntax.text).
+
+----
+
+## Overview
+
+### Philosophy
+
+Markdown is intended to be as easy-to-read and easy-to-write as is feasible.
+
+Readability, however, is emphasized above all else. A Markdown-formatted
+document should be publishable as-is, as plain text, without looking
+like it's been marked up with tags or formatting instructions. While
+Markdown's syntax has been influenced by several existing text-to-HTML
+filters -- including [Setext](http://docutils.sourceforge.net/mirror/setext.html), [atx](http://www.aaronsw.com/2002/atx/), [Textile](http://textism.com/tools/textile/), [reStructuredText](http://docutils.sourceforge.net/rst.html),
+[Grutatext](http://www.triptico.com/software/grutatxt.html), and [EtText](http://ettext.taint.org/doc/) -- the single biggest source of
+inspiration for Markdown's syntax is the format of plain text email.
+
+## Block Elements
+
+### Paragraphs and Line Breaks
+
+A paragraph is simply one or more consecutive lines of text, separated
+by one or more blank lines. (A blank line is any line that looks like a
+blank line -- a line containing nothing but spaces or tabs is considered
+blank.) Normal paragraphs should not be indented with spaces or tabs.
+
+The implication of the "one or more consecutive lines of text" rule is
+that Markdown supports "hard-wrapped" text paragraphs. This differs
+significantly from most other text-to-HTML formatters (including Movable
+Type's "Convert Line Breaks" option) which translate every line break
+character in a paragraph into a `<br />` tag.
+
+When you *do* want to insert a `<br />` break tag using Markdown, you
+end a line with two or more spaces, then type return.
+
+### Headers
+
+Markdown supports two styles of headers, [Setext] [1] and [atx] [2].
+
+Optionally, you may "close" atx-style headers. This is purely
+cosmetic -- you can use this if you think it looks better. The
+closing hashes don't even need to match the number of hashes
+used to open the header. (The number of opening hashes
+determines the header level.)
+
+
+### Blockquotes
+
+Markdown uses email-style `>` characters for blockquoting. If you're
+familiar with quoting passages of text in an email message, then you
+know how to create a blockquote in Markdown. It looks best if you hard
+wrap the text and put a `>` before every line:
+
+> This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
+> consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.
+> Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
+> 
+> Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
+> id sem consectetuer libero luctus adipiscing.
+
+Markdown allows you to be lazy and only put the `>` before the first
+line of a hard-wrapped paragraph:
+
+> This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,
+consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.
+Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
+
+> Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
+id sem consectetuer libero luctus adipiscing.
+
+Blockquotes can be nested (i.e. a blockquote-in-a-blockquote) by
+adding additional levels of `>`:
+
+> This is the first level of quoting.
+>
+> > This is nested blockquote.
+>
+> Back to the first level.
+
+Blockquotes can contain other Markdown elements, including headers, lists,
+and code blocks:
+
+> ## This is a header.
+> 
+> 1.   This is the first list item.
+> 2.   This is the second list item.
+> 
+> Here's some example code:
+> 
+>     return shell_exec("echo $input | $markdown_script");
+
+Any decent text editor should make email-style quoting easy. For
+example, with BBEdit, you can make a selection and choose Increase
+Quote Level from the Text menu.
+
+
+### Lists
+
+Markdown supports ordered (numbered) and unordered (bulleted) lists.
+
+Unordered lists use asterisks, pluses, and hyphens -- interchangably
+-- as list markers:
+
+*   Red
+*   Green
+*   Blue
+
+is equivalent to:
+
++   Red
++   Green
++   Blue
+
+and:
+
+-   Red
+-   Green
+-   Blue
+
+Ordered lists use numbers followed by periods:
+
+1.  Bird
+2.  McHale
+3.  Parish
+
+It's important to note that the actual numbers you use to mark the
+list have no effect on the HTML output Markdown produces. The HTML
+Markdown produces from the above list is:
+
+If you instead wrote the list in Markdown like this:
+
+1.  Bird
+1.  McHale
+1.  Parish
+
+or even:
+
+3. Bird
+1. McHale
+8. Parish
+
+you'd get the exact same HTML output. The point is, if you want to,
+you can use ordinal numbers in your ordered Markdown lists, so that
+the numbers in your source match the numbers in your published HTML.
+But if you want to be lazy, you don't have to.
+
+To make lists look nice, you can wrap items with hanging indents:
+
+*   Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+    Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi,
+    viverra nec, fringilla in, laoreet vitae, risus.
+*   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
+    Suspendisse id sem consectetuer libero luctus adipiscing.
+
+But if you want to be lazy, you don't have to:
+
+*   Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi,
+viverra nec, fringilla in, laoreet vitae, risus.
+*   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
+Suspendisse id sem consectetuer libero luctus adipiscing.
+
+List items may consist of multiple paragraphs. Each subsequent
+paragraph in a list item must be indented by either 4 spaces
+or one tab:
+
+1.  This is a list item with two paragraphs. Lorem ipsum dolor
+    sit amet, consectetuer adipiscing elit. Aliquam hendrerit
+    mi posuere lectus.
+
+    Vestibulum enim wisi, viverra nec, fringilla in, laoreet
+    vitae, risus. Donec sit amet nisl. Aliquam semper ipsum
+    sit amet velit.
+
+2.  Suspendisse id sem consectetuer libero luctus adipiscing.
+
+It looks nice if you indent every line of the subsequent
+paragraphs, but here again, Markdown will allow you to be
+lazy:
+
+*   This is a list item with two paragraphs.
+
+    This is the second paragraph in the list item. You're
+only required to indent the first line. Lorem ipsum dolor
+sit amet, consectetuer adipiscing elit.
+
+*   Another item in the same list.
+
+To put a blockquote within a list item, the blockquote's `>`
+delimiters need to be indented:
+
+*   A list item with a blockquote:
+
+    > This is a blockquote
+    > inside a list item.
+
+To put a code block within a list item, the code block needs
+to be indented *twice* -- 8 spaces or two tabs:
+
+*   A list item with a code block:
+
+        <code goes here>
+
+### Code Blocks
+
+Pre-formatted code blocks are used for writing about programming or
+markup source code. Rather than forming normal paragraphs, the lines
+of a code block are interpreted literally. Markdown wraps a code block
+in both `<pre>` and `<code>` tags.
+
+To produce a code block in Markdown, simply indent every line of the
+block by at least 4 spaces or 1 tab.
+
+This is a normal paragraph:
+
+    This is a code block.
+
+Here is an example of AppleScript:
+
+    tell application "Foo"
+        beep
+    end tell
+
+A code block continues until it reaches a line that is not indented
+(or the end of the article).
+
+Within a code block, ampersands (`&`) and angle brackets (`<` and `>`)
+are automatically converted into HTML entities. This makes it very
+easy to include example HTML source code using Markdown -- just paste
+it and indent it, and Markdown will handle the hassle of encoding the
+ampersands and angle brackets. For example, this:
+
+    <div class="footer">
+        &copy; 2004 Foo Corporation
+    </div>
+
+Regular Markdown syntax is not processed within code blocks. E.g.,
+asterisks are just literal asterisks within a code block. This means
+it's also easy to use Markdown to write about Markdown's own syntax.
+
+```
+tell application "Foo"
+    beep
+end tell
+```
+
+## Span Elements
+
+### Links
+
+Markdown supports two style of links: *inline* and *reference*.
+
+In both styles, the link text is delimited by [square brackets].
+
+To create an inline link, use a set of regular parentheses immediately
+after the link text's closing square bracket. Inside the parentheses,
+put the URL where you want the link to point, along with an *optional*
+title for the link, surrounded in quotes. For example:
+
+This is [an example](http://example.com/) inline link.
+
+[This link](http://example.net/) has no title attribute.
+
+### Emphasis
+
+Markdown treats asterisks (`*`) and underscores (`_`) as indicators of
+emphasis. Text wrapped with one `*` or `_` will be wrapped with an
+HTML `<em>` tag; double `*`'s or `_`'s will be wrapped with an HTML
+`<strong>` tag. E.g., this input:
+
+*single asterisks*
+
+_single underscores_
+
+**double asterisks**
+
+__double underscores__
+
+### Code
+
+To indicate a span of code, wrap it with backtick quotes (`` ` ``).
+Unlike a pre-formatted code block, a code span indicates code within a
+normal paragraph. For example:
+
+Use the `printf()` function.


### PR DESCRIPTION
用真实/合成的「全要素」Markdown 做更完整的转换测试，补齐两处转换器缺口。

## 转换器改进（`src/from-md.ts`）
- **脚注定义** `[^id]: 正文`（含缩进续行）→ `=== note {#id}` 流式块，使对应 `[^id]` 引用在构建时可解析（§5.2）。此前定义行会退化为段落、引用悬空。
- **autolink** `<https://…>` / `<mailto:…>` → GEML 链接 `[url](url)`，仅在行内代码段之外处理，不再误报为 raw HTML。

## 测试（共 29 项全绿）
- `test/fixtures/kitchensink.md`：frontmatter / 标题(ATX+setext) / 强调·加重·删除线 / 行内与块级数学 / 对齐表格 / js 与内嵌 GEML 代码围栏 / 引用 / 嵌套列表 / 任务列表 / 图片 / 链接 / 脚注 / 分隔线 / 转义 —— 转换+解析**零错误**。
- `test/fixtures/markdown-syntax.md`（John Gruber「Markdown: Syntax」）：演示 §8 参照校验在真实文档上抓出 16+ 个悬空目录锚点（源文档依赖外部 HTML 锚点）。
- `test/fixtures.test.mjs`：上述断言。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8fQ5A5Q3zNfLDza1sZUTu)_