### PR TITLE
feat: typed block 自动 id、mermaid→diagram、媒体 as 按扩展名推断

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,18 @@ GEML's typed-block primitive (inline syntax passes through, being a subset):
 |----------|------|
 | YAML frontmatter | `=== meta` (data) |
 | ` ``` ` fenced code | `=== code {lang=…}` |
+| ` ```mermaid `/`graphviz`/`dot`/`d2`/`plantuml` | `=== diagram {format=…}` (§7) |
 | `$$ … $$` math | `=== math` |
 | `>` blockquote | `=== note` |
 | GFM pipe table | `=== table` (§6) |
+| `[^id]: …` footnote def | `=== note {#id}` |
+| `<https://…>` autolink | `[url](url)` |
 | setext heading | ATX heading |
 | thematic break (`---`) | dropped (not a GEML construct) |
+
+Converted typed blocks get auto-assigned `#type-N` ids so they are
+referenceable; media embeds (`![](clip.mp4)`) get their `as` kind inferred from
+the source extension (§5.1).
 
 Milestones:
 

--- a/geml-parser/src/from-md.ts
+++ b/geml-parser/src/from-md.ts
@@ -31,12 +31,22 @@ function fenceFor(body: string[]): string {
   return "=".repeat(Math.max(3, max + 1));
 }
 
-function emitBlock(out: string[], type: string, attrs: string, body: string[]): void {
+// Emit a typed block, auto-assigning a stable `#type-N` id (so converted blocks
+// are referenceable) unless one was already supplied or the block is `meta`.
+function emitBlock(out: string[], type: string, attrs: string, body: string[], ids?: Record<string, number>): void {
+  if (ids && type !== "meta" && !attrs.includes("#")) {
+    const n = (ids[type] = (ids[type] ?? 0) + 1);
+    const idAttr = `#${type}-${n}`;
+    attrs = attrs ? attrs.replace(/^\{/, `{${idAttr} `) : `{${idAttr}}`;
+  }
   const fence = fenceFor(body);
   out.push(attrs ? `${fence} ${type} ${attrs}` : `${fence} ${type}`);
   out.push(...body);
   out.push(fence);
 }
+
+// Fenced-code info strings that denote a diagram DSL (§7) rather than code.
+const DIAGRAM_LANGS = new Set(["mermaid", "graphviz", "dot", "d2", "plantuml"]);
 
 // `key: value` (YAML-ish) -> `key=value`, quoting values that need it.
 function metaLine(line: string): string | null {
@@ -88,6 +98,7 @@ export function mdToGeml(source: string): ConvertResult {
   const lines = source.replace(/\r\n?/g, "\n").split("\n");
   const out: string[] = [];
   const notes: string[] = [];
+  const ids: Record<string, number> = {}; // per-type id counters for auto-ids
   let i = 0;
 
   // YAML frontmatter (must be the very first line).
@@ -101,7 +112,7 @@ export function mdToGeml(source: string): ConvertResult {
       j++;
     }
     if (j < lines.length) { // closing marker found -> it was frontmatter
-      emitBlock(out, "meta", "", meta);
+      emitBlock(out, "meta", "", meta, ids);
       out.push("");
       i = j + 1;
     }
@@ -122,7 +133,8 @@ export function mdToGeml(source: string): ConvertResult {
         if (c.startsWith(marker[0]!) && c.replace(/\s+$/, "").length >= marker.length && /^[`~]+$/.test(c.replace(/\s+$/, ""))) break;
         body.push(lines[j]!);
       }
-      emitBlock(out, "code", info ? `{lang=${info}}` : "", body);
+      if (DIAGRAM_LANGS.has(info)) emitBlock(out, "diagram", `{format=${info}}`, body, ids);
+      else emitBlock(out, "code", info ? `{lang=${info}}` : "", body, ids);
       i = j < lines.length ? j + 1 : j;
       continue;
     }
@@ -132,7 +144,7 @@ export function mdToGeml(source: string): ConvertResult {
       const body: string[] = [];
       let j = i + 1;
       for (; j < lines.length && lines[j]!.trim() !== "$$"; j++) body.push(lines[j]!);
-      emitBlock(out, "math", "", body);
+      emitBlock(out, "math", "", body, ids);
       i = j < lines.length ? j + 1 : j;
       continue;
     }
@@ -165,7 +177,7 @@ export function mdToGeml(source: string): ConvertResult {
         else if (lines[j]!.trim() === "") break;
         else break;
       }
-      emitBlock(out, "note", `{#${fn[1]!.trim()}}`, body.map(autolinks));
+      emitBlock(out, "note", `{#${fn[1]!.trim()}}`, body.map(autolinks), ids);
       i = j;
       continue;
     }
@@ -177,7 +189,7 @@ export function mdToGeml(source: string): ConvertResult {
         body.push(lines[i]!.replace(/^\s*>\s?/, ""));
         i++;
       }
-      emitBlock(out, "note", "", body);
+      emitBlock(out, "note", "", body, ids);
       continue;
     }
 
@@ -188,7 +200,7 @@ export function mdToGeml(source: string): ConvertResult {
       body.push(lines[j]!); // separator
       j++;
       while (j < lines.length && lines[j]!.includes("|") && lines[j]!.trim() !== "") { body.push(lines[j]!); j++; }
-      emitBlock(out, "table", "", body);
+      emitBlock(out, "table", "", body, ids);
       i = j;
       continue;
     }

--- a/geml-parser/src/inline.ts
+++ b/geml-parser/src/inline.ts
@@ -44,6 +44,17 @@ export interface RefSink {
 
 const SCHEME = /^[a-z][a-z0-9+.-]*:/i; // http:, https:, mailto:, …
 
+// §5.1: when `as` is omitted, infer the media kind from the source extension.
+const VIDEO_EXT = /\.(mp4|webm|mov|m4v|ogv|mkv)(?:[?#].*)?$/i;
+const AUDIO_EXT = /\.(mp3|wav|ogg|oga|m4a|flac|aac|opus)(?:[?#].*)?$/i;
+const IMAGE_EXT = /\.(png|jpe?g|gif|webp|svg|avif|bmp|ico|tiff?)(?:[?#].*)?$/i;
+function inferAs(src: string): "image" | "audio" | "video" | undefined {
+  if (VIDEO_EXT.test(src)) return "video";
+  if (AUDIO_EXT.test(src)) return "audio";
+  if (IMAGE_EXT.test(src)) return "image";
+  return undefined;
+}
+
 // Classify a link/image destination into {href|doc, anchor}.
 function classifyDest(dest: string): { href?: string; doc?: string; anchor?: string } {
   const d = dest.trim();
@@ -169,6 +180,7 @@ function scanAtoms(s: string, line: number, sink: RefSink): (string | Inline)[] 
         };
         const as = attrObj.attrs["as"];
         if (typeof as === "string") node.as = as;
+        else { const inf = inferAs(node.src); if (inf) node.as = inf; }
         flush();
         out.push(node);
         i = a ? a.end : paren.end;

--- a/geml-parser/test/convert.test.mjs
+++ b/geml-parser/test/convert.test.mjs
@@ -15,10 +15,15 @@ test("YAML frontmatter -> === meta", () => {
   assert.match(g, /n=2/);
 });
 
-test("fenced code -> === code {lang=…}", () => {
+test("fenced code -> === code {lang=…} with auto-id", () => {
   const g = conv("```python\nx = 1\n```\n");
-  assert.match(g, /=== code \{lang=python\}/);
+  assert.match(g, /=== code \{#code-1 lang=python\}/);
   assert.match(g, /x = 1/);
+});
+
+test("known diagram DSL fences -> === diagram {format=…}", () => {
+  const g = conv("```mermaid\ngraph LR\nA-->B\n```\n");
+  assert.match(g, /=== diagram \{#diagram-1 format=mermaid\}/);
 });
 
 test("fence grows past `===` lines in the body", () => {
@@ -28,12 +33,12 @@ test("fence grows past `===` lines in the body", () => {
 
 test("blockquote -> === note", () => {
   const g = conv("> line one\n> line two\n");
-  assert.match(g, /=== note\nline one\nline two\n===/);
+  assert.match(g, /=== note \{#note-1\}\nline one\nline two\n===/);
 });
 
 test("GFM table -> === table (visual body)", () => {
   const g = conv("| A | B |\n|---|--:|\n| 1 | 2 |\n");
-  assert.match(g, /=== table\n\| A \| B \|/);
+  assert.match(g, /=== table \{#table-1\}\n\| A \| B \|/);
   const t = parse(g).children[0].table;
   assert.deepEqual(t.columns, ["A", "B"]);
   assert.equal(t.align[1], "right");
@@ -46,7 +51,7 @@ test("setext headings -> ATX", () => {
 });
 
 test("display math -> === math", () => {
-  assert.match(conv("$$\nE=mc^2\n$$\n"), /=== math\nE=mc\^2\n===/);
+  assert.match(conv("$$\nE=mc^2\n$$\n"), /=== math \{#math-1\}\nE=mc\^2\n===/);
 });
 
 test("thematic break is dropped with a note", () => {

--- a/geml-parser/test/fixtures.test.mjs
+++ b/geml-parser/test/fixtures.test.mjs
@@ -33,7 +33,19 @@ test("kitchen sink: every construct converts and parses with zero errors", () =>
   assert.deepEqual(table.table.align, ["left", "center", "right"]);
 
   // embedded GEML example: inner `===` forces a longer outer fence
-  assert.match(geml, /^==== code \{lang=geml\}$/m);
+  assert.match(geml, /^==== code \{#code-\d+ lang=geml\}$/m);
+
+  // mermaid fence -> diagram block (§7), not a code block
+  const diagram = doc.children.find((b) => b.type === "diagram");
+  assert.equal(diagram.attrs.format, "mermaid");
+
+  // media kind inferred from the source extension (§5.1)
+  const media = [];
+  for (const b of doc.children) for (const n of b.inlines ?? []) if (n.type === "image") media.push(n.as);
+  assert.deepEqual(media.sort(), ["audio", "image", "video"]);
+
+  // typed blocks get auto-generated ids so they are referenceable
+  assert.ok(doc.ids.includes("math-1") && doc.ids.includes("diagram-1"));
 
   // only the thematic-break drop is expected as a note
   assert.ok(notes.every((n) => /thematic break/.test(n)), JSON.stringify(notes));

--- a/geml-parser/test/fixtures/kitchensink.md
+++ b/geml-parser/test/fixtures/kitchensink.md
@@ -93,6 +93,18 @@ An inline link to [Anthropic](https://www.anthropic.com) and an image:
 
 ![alt text](https://example.com/pic.png)
 
+A video embed ![demo clip](https://example.com/clip.mp4) and an audio embed
+![theme](https://example.com/theme.mp3) inline.
+
 An autolink: <https://commonmark.org>.
+
+## Diagram {#diagram}
+
+```mermaid
+graph LR
+  A[Draft] --> B{Review}
+  B -->|ok| C[Publish]
+  B -->|back| A
+```
 
 [^note]: This is the footnote body.

--- a/geml-parser/test/m2.test.mjs
+++ b/geml-parser/test/m2.test.mjs
@@ -40,6 +40,15 @@ test("media embed with as= (§5.1)", () => {
   assert.equal(img.as, "image");
 });
 
+test("media kind inferred from src extension when `as` omitted (§5.1)", () => {
+  const kind = (src) => parse(`![x](${src})`).children[0].inlines[0].as;
+  assert.equal(kind("a.png"), "image");
+  assert.equal(kind("a.mp4"), "video");
+  assert.equal(kind("a.mp3?x=1"), "audio");
+  assert.equal(kind("https://h/x"), undefined); // no extension -> left to renderer
+  assert.equal(parse("![x](a.png){as=video}").children[0].inlines[0].as, "video"); // explicit wins
+});
+
 test("resolved internal/auto/footnote refs are clean (§5.2)", () => {
   const d = parse("# Title {#sec}\n\nSee [text](#sec) and [[#sec]] and [^sec].");
   assert.equal(d.diagnostics.length, 0, JSON.stringify(d.diagnostics));


### PR DESCRIPTION
## 改动
- **typed block 自动 id**：转换产生的 `code`/`math`/`diagram`/`table`/`note` 块自动分配 `#type-N` id（`meta` 除外、已显式带 id 的保留），使其可被引用。
- **mermaid→diagram**：已知图形 DSL 围栏（`mermaid`/`graphviz`/`dot`/`d2`/`plantuml`）映射为 `=== diagram {format=…}`，而非 `=== code`（§7）。
- **媒体 `as` 推断**：图片/媒体嵌入省略 `as` 时，解析器按源扩展名推断 `image`/`audio`/`video`（§5.1）；显式 `as` 优先。

## 测试
- 扩展 `kitchensink.md`：新增 **mermaid diagram、video(.mp4)、audio(.mp3)**，连同既有 **image/code/math** 一并覆盖你关心的全部类型。
- 新增 `as` 推断单测 + diagram/媒体断言；**`npm test` 共 31 项全部通过**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8fQ5A5Q3zNfLDza1sZUTu)_