### PR TITLE
docs: 修正 geml-chart 示例的表 id（#fy→#fy25）与措辞

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -118,7 +118,7 @@ Org-mode    See [[budget]]           → partially checked on export
 ### Table with computed columns (GEML-specific)
 
 ```
-GEML        === table {#fy format=csv header=1
+GEML        === table {#fy25 format=csv header=1
               compute="FY [%.1f] = Q1 + Q2 + Q3 + Q4"
               summary="Segment = 'Total'; FY = sum(FY)"}
             Segment, Q1, Q2, Q3, Q4
@@ -159,7 +159,7 @@ HTML/CMark  no native diagram hosting
 
 ```
 GEML        === diagram {#rev format=geml-chart data=#fy25 type=bar x=Segment y=FY}
-            ===                       → draws table #fy25; column refs checked
+            ===                       → renders table #fy25 as a chart; column refs checked
 others      hand-copy data into a chart lib, or a spreadsheet app — no link
 ```
 

--- a/COMPARISON_CN.md
+++ b/COMPARISON_CN.md
@@ -115,7 +115,7 @@ Org-mode    见 [[budget]]           → 导出时部分校验
 ### 带计算列的表格（GEML 独有）
 
 ```
-GEML        === table {#fy format=csv header=1
+GEML        === table {#fy25 format=csv header=1
               compute="FY [%.1f] = Q1 + Q2 + Q3 + Q4"
               summary="Segment = 'Total'; FY = sum(FY)"}
             Segment, Q1, Q2, Q3, Q4
@@ -156,7 +156,7 @@ HTML/CMark  无原生图形托管
 
 ```
 GEML        === diagram {#rev format=geml-chart data=#fy25 type=bar x=Segment y=FY}
-            ===                       → 画 #fy25 表；列引用受校验
+            ===                       → 把表 #fy25 渲染成图表；列引用受校验
 其他格式      手抄数据进图表库，或用电子表格 App —— 无链接
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Write a table visually:
 …or as data, with **computed columns** and a **summary row**:
 
 ```
-=== table {#fy format=csv header=1 compute="FY [%.1f] = Q1 + Q2 + Q3 + Q4" summary="Segment = 'Total'; FY = sum(FY)"}
+=== table {#fy25 format=csv header=1 compute="FY [%.1f] = Q1 + Q2 + Q3 + Q4" summary="Segment = 'Total'; FY = sum(FY)"}
 Segment, Q1, Q2, Q3, Q4
 Cloud,   1,  2,  3,  4
 ===
@@ -126,7 +126,7 @@ graph LR
 ===
 ```
 
-A diagram can also **draw a table**: `=== diagram {format=geml-chart data=#fy25 type=bar x=Segment y=FY}` binds to table `#fy25` (single source of truth) and validates the column references at build time. Complex charts fall back to a hosted DSL like `format=vega-lite` with the spec in the body.
+A diagram can also **render a table as a chart**: `=== diagram {format=geml-chart data=#fy25 type=bar x=Segment y=FY}` reads table `#fy25` (single source of truth) and validates the column references at build time. Complex charts fall back to a hosted DSL like `format=vega-lite` with the spec in the body.
 
 ### Math
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -107,7 +107,7 @@ version = 0.1
 ……或写成数据形态，带**计算列**与**汇总行**：
 
 ```
-=== table {#fy format=csv header=1 compute="FY [%.1f] = Q1 + Q2 + Q3 + Q4" summary="Segment = 'Total'; FY = sum(FY)"}
+=== table {#fy25 format=csv header=1 compute="FY [%.1f] = Q1 + Q2 + Q3 + Q4" summary="Segment = 'Total'; FY = sum(FY)"}
 Segment, Q1, Q2, Q3, Q4
 Cloud,   1,  2,  3,  4
 ===
@@ -126,7 +126,7 @@ graph LR
 ===
 ```
 
-图形还能**画数据表**：`=== diagram {format=geml-chart data=#fy25 type=bar x=Segment y=FY}` 绑定到表 `#fy25`（单一真相），并在构建期校验列引用。复杂图退回托管 DSL，如 `format=vega-lite`、spec 写进 body。
+图形还能**把表格渲染成图表**：`=== diagram {format=geml-chart data=#fy25 type=bar x=Segment y=FY}` 读取表 `#fy25`（单一真相），并在构建期校验列引用。复杂图退回托管 DSL，如 `format=vega-lite`、spec 写进 body。
 
 ### 数学
 


### PR DESCRIPTION
小文字修正（geml-chart 示例）：

- **表 id `#fy` → `#fy25`**：与下方 `diagram` 的 `data=#fy25` 引用及核心规范保持一致。此前表是 `#fy`、图引用 `#fy25`，对不上（引用悬空）。
- **措辞**：`draw a table` / `画数据表` 不准确——图表是读取表数据后**渲染成图表**，并非“画一张表”。改为 “render a table as a chart” / “把表格渲染成图表”。

覆盖 README + COMPARISON（中英）。修正后该示例经参考解析器验证 **0 诊断**，列引用通过校验。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8fQ5A5Q3zNfLDza1sZUTu)_