### PR TITLE
docs(readme): 表格/图形加所见渲染，数学换更丰富示例

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,17 +101,36 @@ Write a table visually:
 | Plan  | Months | Rate |
 |-------|-------:|-----:|
 | Basic |      1 |   30 |
+| Pro   |      2 |   30 |
 ===
 ```
+
+*Renders as:*
+
+| Plan  | Months | Rate |
+|-------|-------:|-----:|
+| Basic |      1 |   30 |
+| Pro   |      2 |   30 |
 
 …or as data, with **computed columns** and a **summary row**:
 
 ```
-=== table {#fy25 format=csv header=1 compute="FY [%.1f] = Q1 + Q2 + Q3 + Q4" summary="Segment = 'Total'; FY = sum(FY)"}
-Segment, Q1, Q2, Q3, Q4
-Cloud,   1,  2,  3,  4
+=== table {#fy25 format=csv header=1 compute="FY [%.1f] = Q1 + Q2 + Q3 + Q4" summary="Segment = 'Total'; FY [%.1f] = sum(FY)"}
+Segment,  Q1, Q2, Q3, Q4
+Cloud,     8, 10, 12, 14
+Platform,  5,  6,  7,  9
+Services,  3,  4,  4,  5
 ===
 ```
+
+*Renders as (the `FY` column and `Total` row are computed at build time):*
+
+| Segment   | Q1 | Q2 | Q3 | Q4 |   FY |
+|-----------|---:|---:|---:|---:|-----:|
+| Cloud     |  8 | 10 | 12 | 14 | 44.0 |
+| Platform  |  5 |  6 |  7 |  9 | 27.0 |
+| Services  |  3 |  4 |  4 |  5 | 16.0 |
+| **Total** |    |    |    |    | **87.0** |
 
 `compute` runs `+ - * / ( )` per row over columns (by header name or letter); `summary` adds one foot row built from the aggregates `sum / avg / min / max / count` (with arithmetic over them, e.g. weighted ratios). A trailing `[printf]` like `[%.1f]` or `[%.1f%%]` sets numeric display. Merge cells with `span="r2c1:2x1"`. Both forms describe the same table model.
 
@@ -126,15 +145,36 @@ graph LR
 ===
 ```
 
-A diagram can also **render a table as a chart**: `=== diagram {format=geml-chart data=#fy25 type=bar x=Segment y=FY}` reads table `#fy25` (single source of truth) and validates the column references at build time. Complex charts fall back to a hosted DSL like `format=vega-lite` with the spec in the body.
+*Renders as:*
+
+```mermaid
+graph LR
+  A[Draft] --> B{Review} -->|ok| C[Publish]
+```
+
+A diagram can also **render a table as a chart**: `=== diagram {format=geml-chart data=#fy25 type=bar x=Segment y=FY}` reads table `#fy25` (single source of truth) and validates the column references at build time — no data is copied. Complex charts fall back to a hosted DSL like `format=vega-lite` with the spec in the body.
+
+*That chart, drawn from the `#fy25` table above, renders as:*
+
+```mermaid
+xychart-beta
+  title "FY by segment"
+  x-axis [Cloud, Platform, Services]
+  y-axis "FY"
+  bar [44, 27, 16]
+```
 
 ### Math
 
 ```
-=== math {#steady caption="Steady state"}
-y^* = a / k
+=== math {#gauss caption="Gaussian integral"}
+\int_{-\infty}^{\infty} e^{-x^2}\,dx = \sqrt{\pi}
 ===
 ```
+
+*Renders as:*
+
+$$\int_{-\infty}^{\infty} e^{-x^2}\,dx = \sqrt{\pi}$$
 
 ## Built for AI and agents
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -101,17 +101,36 @@ version = 0.1
 | Plan  | Months | Rate |
 |-------|-------:|-----:|
 | Basic |      1 |   30 |
+| Pro   |      2 |   30 |
 ===
 ```
+
+*渲染为：*
+
+| Plan  | Months | Rate |
+|-------|-------:|-----:|
+| Basic |      1 |   30 |
+| Pro   |      2 |   30 |
 
 ……或写成数据形态，带**计算列**与**汇总行**：
 
 ```
-=== table {#fy25 format=csv header=1 compute="FY [%.1f] = Q1 + Q2 + Q3 + Q4" summary="Segment = 'Total'; FY = sum(FY)"}
-Segment, Q1, Q2, Q3, Q4
-Cloud,   1,  2,  3,  4
+=== table {#fy25 format=csv header=1 compute="FY [%.1f] = Q1 + Q2 + Q3 + Q4" summary="Segment = 'Total'; FY [%.1f] = sum(FY)"}
+Segment,  Q1, Q2, Q3, Q4
+Cloud,     8, 10, 12, 14
+Platform,  5,  6,  7,  9
+Services,  3,  4,  4,  5
 ===
 ```
+
+*渲染为（`FY` 列与 `Total` 行在构建期算出）：*
+
+| Segment   | Q1 | Q2 | Q3 | Q4 |   FY |
+|-----------|---:|---:|---:|---:|-----:|
+| Cloud     |  8 | 10 | 12 | 14 | 44.0 |
+| Platform  |  5 |  6 |  7 |  9 | 27.0 |
+| Services  |  3 |  4 |  4 |  5 | 16.0 |
+| **Total** |    |    |    |    | **87.0** |
 
 `compute` 对各列（按表头名或列字母）逐行做 `+ - * / ( )` 运算；`summary` 用聚合 `sum / avg / min / max / count`（并可对聚合结果再做算术，如加权比率）生成表尾一行。列名后附 `[printf]`（如 `[%.1f]`、`[%.1f%%]`）控制数字显示。合并单元格用 `span="r2c1:2x1"`。两种形态描述的是同一个表格模型。
 
@@ -126,15 +145,36 @@ graph LR
 ===
 ```
 
-图形还能**把表格渲染成图表**：`=== diagram {format=geml-chart data=#fy25 type=bar x=Segment y=FY}` 读取表 `#fy25`（单一真相），并在构建期校验列引用。复杂图退回托管 DSL，如 `format=vega-lite`、spec 写进 body。
+*渲染为：*
+
+```mermaid
+graph LR
+  A[Draft] --> B{Review} -->|ok| C[Publish]
+```
+
+图形还能**把表格渲染成图表**：`=== diagram {format=geml-chart data=#fy25 type=bar x=Segment y=FY}` 读取表 `#fy25`（单一真相），并在构建期校验列引用——不复制数据。复杂图退回托管 DSL，如 `format=vega-lite`、spec 写进 body。
+
+*这张图表（取自上面的 `#fy25` 表）渲染为：*
+
+```mermaid
+xychart-beta
+  title "FY by segment"
+  x-axis [Cloud, Platform, Services]
+  y-axis "FY"
+  bar [44, 27, 16]
+```
 
 ### 数学
 
 ```
-=== math {#steady caption="Steady state"}
-y^* = a / k
+=== math {#gauss caption="Gaussian integral"}
+\int_{-\infty}^{\infty} e^{-x^2}\,dx = \sqrt{\pi}
 ===
 ```
+
+*渲染为：*
+
+$$\int_{-\infty}^{\infty} e^{-x^2}\,dx = \sqrt{\pi}$$
 
 ## 为 AI 与智能体而生
 


### PR DESCRIPTION
回应两点反馈（README + README_CN）：

**1. Math 换更丰富符号的示例**
`y^* = a / k` → 高斯积分 `∫_{-∞}^{∞} e^{-x²} dx = √π`（含积分、无穷限、指数、根号、π），并用 `$$…$$` 给出 GitHub 渲染。

**2. Tables / Diagrams 加「所见」渲染**（借 GitHub 原生渲染）
- 可视化表 → 下方 GFM 渲染表
- 计算表 → 扩为 3 个 segment，下方 GFM 渲染表展示**构建期算出**的 `FY` 列（44.0/27.0/16.0）与 `Total` 行（87.0）
- mermaid 流程图 → 真实 ` ```mermaid ` 渲染
- geml-chart 柱状图 → 用 ` ```mermaid xychart-beta ` 渲染，数据与 `#fy25` 表一致

改动的 GEML 源片段均经解析器验证 **0 诊断**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8fQ5A5Q3zNfLDza1sZUTu)_