### PR TITLE
docs(readme): 数学示例去掉 dx 前的 \,

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,13 +168,13 @@ xychart-beta
 
 ```
 === math {#gauss caption="Gaussian integral"}
-\int_{-\infty}^{\infty} e^{-x^2}\,dx = \sqrt{\pi}
+\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}
 ===
 ```
 
 *Renders as:*
 
-$$\int_{-\infty}^{\infty} e^{-x^2}\,dx = \sqrt{\pi}$$
+$$\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}$$
 
 ## Built for AI and agents
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -168,13 +168,13 @@ xychart-beta
 
 ```
 === math {#gauss caption="Gaussian integral"}
-\int_{-\infty}^{\infty} e^{-x^2}\,dx = \sqrt{\pi}
+\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}
 ===
 ```
 
 *渲染为：*
 
-$$\int_{-\infty}^{\infty} e^{-x^2}\,dx = \sqrt{\pi}$$
+$$\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}$$
 
 ## 为 AI 与智能体而生
 


### PR DESCRIPTION
Math 示例去掉 `dx` 前的 `\,`（LaTeX 细空格命令）——在 GEML 源码块里它看着像逗号，容易误读。改为 `e^{-x^2} dx`，公式仍正确，`$$` 渲染不受影响。README + README_CN 同步。

（顺带回答上个问题：Markdown **不支持**用缩进做章节递进——标题层级只由 `#` 个数决定，缩进在 MD 里表示代码块/子列表。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8fQ5A5Q3zNfLDza1sZUTu)_