### PR TITLE
fix(cli): run under npm's extensionless bin symlink — resolve argv[1]…

### DIFF
--- a/geml-parser/src/geml.ts
+++ b/geml-parser/src/geml.ts
@@ -9,7 +9,7 @@
 // media embeds, links, auto-references, footnotes) and build-time reference
 // validation (§8 — unique ids, resolvable internal/cross-document references).
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync, realpathSync } from "node:fs";
 import { basename, dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
@@ -1052,8 +1052,18 @@ function runCodemap(args: string[]): void {
   process.exit(r.status ?? 1);
 }
 
-const entry = process.argv[1] ?? "";
-if (entry.endsWith("geml.js") || entry.endsWith("geml.ts")) {
+// npm's unix bin shim is a symlink named plain `geml`, so detect "run as a
+// CLI" by resolving argv[1] to its real path, not by its spelling.
+const entry = (() => {
+  const argv1 = process.argv[1];
+  if (!argv1) return "";
+  try {
+    return realpathSync(argv1);
+  } catch {
+    return argv1;
+  }
+})();
+if (entry === fileURLToPath(import.meta.url) || entry.endsWith("geml.ts")) {
   const argv = process.argv.slice(2);
   // The on-disk artifact is `.geml-code-graph/`, so people reconstruct the
   // command from the directory name — accept those spellings as `codemap`.

--- a/geml-parser/test/cli.test.mjs
+++ b/geml-parser/test/cli.test.mjs
@@ -31,6 +31,21 @@ test("--version exits 0 and prints a version", () => {
   assert.match(r.out, /\d/);
 });
 
+test("runs when launched through an extensionless bin symlink (npm's unix shim)", () => {
+  // npm links node_modules/.bin/geml -> dist/geml.js; argv[1] is then the
+  // symlink path, which must still be recognised as the CLI entry.
+  const bin = pjoin(mkdtempSync(pjoin(tmpdir(), "geml-bin-")), "geml");
+  try {
+    symlinkSync(presolve("dist/geml.js"), bin);
+  } catch {
+    console.log("skip (symlinks unavailable)");
+    return;
+  }
+  const r = spawnSync(process.execPath, [bin, "--version"], { encoding: "utf8", timeout: 60_000 });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout ?? "", /\d/, "bin symlink invocation must print the version, not exit silently");
+});
+
 test("no args is a usage error (exit 2) printing usage to stderr", () => {
   const r = run([]);
   assert.equal(r.code, 2);
@@ -149,9 +164,9 @@ test("export exits non-zero on a broken doc (same signal as render)", () => {
 // ---------------------------------------------------------------------------
 
 // A minimal two-document codemap on disk (same shape the emitter writes).
-import { mkdtempSync, mkdirSync, writeFileSync as wf, readFileSync as rf, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync as wf, readFileSync as rf, existsSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join as pjoin } from "node:path";
+import { join as pjoin, resolve as presolve } from "node:path";
 const CODEMAP_DIR = mkdtempSync(pjoin(tmpdir(), "geml-codemap-"));
 wf(pjoin(CODEMAP_DIR, "auth.geml"),
   "=== meta\nmodule = auth\nentry = #login\nresolution-default = cpg\n===\n\n" +


### PR DESCRIPTION
… to its real path

npm's unix bin shim is a symlink named plain 'geml', so the old endsWith('geml.js') entry guard never matched: every npm-installed invocation on Linux/macOS loaded the module and exited silently with status 0. Detect 'run as a CLI' by realpath-comparing argv[1] against import.meta.url instead. Regression test spawns the CLI through such a symlink and asserts --version actually prints.


Claude-Session: https://claude.ai/code/session_015pQvbS2ZAnYjAiUJ9CMn4A